### PR TITLE
fix: clarify api key usage currency

### DIFF
--- a/app/org/[org_id]/apikeys/page.js
+++ b/app/org/[org_id]/apikeys/page.js
@@ -89,6 +89,16 @@ const Page = () => {
     openModal(MODAL_TYPE.CONNECTED_AGENTS_MODAL);
   }, []);
 
+  const formatApiKeyUsage = (usage) => {
+    const numericUsage = Number.parseFloat(usage);
+    return Number.isFinite(numericUsage) ? `$${numericUsage.toFixed(4)}` : "$0.0000";
+  };
+
+  const getColumnLabel = (column) => {
+    if (column === "apikey_usage") return "Usage (USD)";
+    return column.replace(/_/g, " ");
+  };
+
   // Only show API keys for services that currently exist
   const validApiKeys = filterApiKeys.filter((apiKey) => {
     const serviceExists = SERVICES.some((service) => service.value === apiKey?.service);
@@ -99,7 +109,8 @@ const Page = () => {
     ...item,
     actualName: item.name,
     serviceKey: item.service,
-    apikey_usage: item?.apikey_usage ? parseFloat(item.apikey_usage).toFixed(4) : 0,
+    apikey_usage_original: Number.parseFloat(item?.apikey_usage) || 0,
+    apikey_usage: formatApiKeyUsage(item?.apikey_usage),
     service: (
       <div className="flex items-center gap-2">
         {getIconOfService(item.service, 18, 18)}
@@ -253,6 +264,7 @@ const Page = () => {
               endComponent={EndComponent}
               handleRowClick={(data) => showConnectedAgents(data)}
               keysToExtractOnRowClick={["_id", "name", "version_ids"]}
+              customGetColumnLabel={getColumnLabel}
             />
           </div>
         ))

--- a/components/customTable/CustomTable.js
+++ b/components/customTable/CustomTable.js
@@ -98,6 +98,13 @@ const CustomTable = ({
           return ascending ? costA - costB : costB - costA;
         }
 
+        // Numeric sorting for API key usage values even when formatted as currency strings
+        if (activeColumn === "apikey_usage") {
+          const usageA = Number(a.apikey_usage_original ?? a.apikey_usage ?? 0);
+          const usageB = Number(b.apikey_usage_original ?? b.apikey_usage ?? 0);
+          return ascending ? usageA - usageB : usageB - usageA;
+        }
+
         // Keep original sorting for totalTokens column for backward compatibility
         if (activeColumn === "totalTokens") {
           const toNumber = (value) => {

--- a/components/modals/ApiKeyModal.js
+++ b/components/modals/ApiKeyModal.js
@@ -262,6 +262,7 @@ const ApiKeyModal = ({
                 inputMode="decimal"
                 min="0"
               />
+              <p className="text-xs text-base-content/50">Set a limit to avoid overspending.</p>
             </div>
           );
         })}


### PR DESCRIPTION
## What changed
- formatted API key usage values with a currency symbol so entries like `0.0013` render clearly as money
- renamed the usage column header to `Usage (USD)`
- preserved numeric sorting for the usage column after currency formatting

## Why
Users should be able to immediately recognize these values as currency, not plain decimals.

## Notes
- values now display in `$0.0000` format
- merged cleanly with the latest `testing` changes that filter out API keys for removed services