### PR TITLE
fix: improve testcase UI with sticky columns, trim whitespace, and pr…

### DIFF
--- a/app/org/[org_id]/agents/testcase/[id]/page.js
+++ b/app/org/[org_id]/agents/testcase/[id]/page.js
@@ -226,10 +226,10 @@ function TestCases({ params }) {
 
   const getScoreDisplay = (score, matchingType) => {
     const type = (matchingType || "cosine").toLowerCase();
-    if (type === "exact" || type === "ai") {
+    if (type === "exact") {
       return score === 1 ? "Pass" : "Fail";
     }
-    // Cosine shows percentage
+    // AI and Cosine both show percentage (backend returns a fractional score).
     return `${(score * 100).toFixed(0)}%`;
   };
 
@@ -388,19 +388,25 @@ function TestCases({ params }) {
                   scrollableTarget="testcase-list-scrollable"
                   style={{ overflow: "visible" }}
                 >
-                  <table className="w-full border-collapse bg-base-100">
-                    <thead className="bg-base-50 sticky top-0 z-20">
+                  <table className="w-full border-separate border-spacing-0 bg-base-100">
+                    <thead className="bg-base-50">
                       <tr className="border-b border-base-200">
-                        <th className="px-2 py-3 text-left text-xs font-semibold text-base-content uppercase tracking-wider sticky left-0 bg-base-50 w-[40px] z-30">
+                        <th
+                          style={{ left: 0, width: 48, minWidth: 48 }}
+                          className="px-2 py-3 text-left text-xs font-semibold text-base-content uppercase tracking-wider sticky bg-base-50 z-30"
+                        >
                           #
                         </th>
-                        <th className="px-2 py-3 text-left text-xs font-semibold text-base-content uppercase tracking-wider sticky left-[40px] bg-base-50 w-[140px] z-30">
+                        <th
+                          style={{ left: 48, width: 140, minWidth: 140 }}
+                          className="px-2 py-3 text-left text-xs font-semibold text-base-content uppercase tracking-wider sticky bg-base-50 z-30"
+                        >
                           Input
                         </th>
                         {selectedVersions.map((version, idx) => (
                           <th
                             key={idx}
-                            className="px-2 py-3 text-center text-xs font-semibold text-base-content uppercase tracking-wider min-w-[60px] bg-base-50 z-20"
+                            className="px-2 py-3 text-center text-xs font-semibold text-base-content uppercase tracking-wider min-w-[60px] bg-base-50 "
                           >
                             v{versions.indexOf(version) + 1}
                           </th>
@@ -427,12 +433,14 @@ function TestCases({ params }) {
                               className={`cursor-pointer transition-all ${isSelected ? "bg-base-200" : "bg-base-100 hover:bg-base-50"}`}
                             >
                               <td
-                                className={`px-2 py-3.5 text-sm sticky left-0 z-10 w-[40px] ${isSelected ? "bg-base-200 font-semibold" : "bg-base-100 font-medium"} text-base-content`}
+                                style={{ left: 0, width: 48, minWidth: 48 }}
+                                className={`px-2 py-3.5 text-sm sticky z-20 ${isSelected ? "bg-base-200 font-semibold" : "bg-base-100 font-medium"} text-base-content`}
                               >
                                 {index + 1}
                               </td>
                               <td
-                                className={`px-2 py-3.5 text-sm sticky left-[40px] z-10 w-[140px] ${isSelected ? "bg-base-200 font-semibold" : "bg-base-100 font-medium"} text-base-content whitespace-nowrap overflow-hidden text-ellipsis`}
+                                style={{ left: 48, width: 140, minWidth: 140 }}
+                                className={`px-2 py-3.5 text-sm sticky z-20 ${isSelected ? "bg-base-200 font-semibold" : "bg-base-100 font-medium"} text-base-content whitespace-nowrap overflow-hidden text-ellipsis`}
                               >
                                 {lastUserMessage?.substring(0, 20)}
                                 {lastUserMessage?.length > 20 ? "..." : ""}
@@ -462,7 +470,8 @@ function TestCases({ params }) {
                                         </span>
                                       ) : (
                                         <span
-                                          className={`text-xs font-semibold ${getScoreColor(score, matchingTypeFromResult)}`}
+                                          className={`text-xs font-semibold cursor-help ${getScoreColor(score, matchingTypeFromResult)}`}
+                                          title={getScoreMessage(score, matchingTypeFromResult)}
                                         >
                                           {getScoreDisplay(score, matchingTypeFromResult)}
                                         </span>

--- a/components/testcaseComponents/TestCaseDetailsPanel.js
+++ b/components/testcaseComponents/TestCaseDetailsPanel.js
@@ -85,8 +85,12 @@ const TestCaseDetailsPanel = ({
   }, [selectedTestCase?._id]);
 
   const handleMatchingTypeChange = async (newType) => {
-    setMatchingType(newType);
     setIsMatchingDropdownOpen(false);
+    const nextType = newType.toLowerCase();
+    const currentType = (selectedTestCase?.matching_type || "").toLowerCase();
+    // Skip API call if user re-selected the same matching type.
+    if (nextType === currentType) return;
+    setMatchingType(newType);
     await dispatch(
       updateTestCaseAction({
         testCaseId: selectedTestCase?._id,
@@ -94,44 +98,84 @@ const TestCaseDetailsPanel = ({
           conversation: selectedTestCase?.conversation,
           type: selectedTestCase?.type,
           expected: selectedTestCase?.expected,
-          matching_type: newType.toLowerCase(),
+          matching_type: nextType,
           variables: selectedTestCase?.variables,
         },
       })
     );
   };
 
-  // Detect unsaved changes
+  const trimConversation = (conv) =>
+    (conv || []).map((m) => ({
+      ...m,
+      content: typeof m?.content === "string" ? m.content.trim() : m?.content,
+    }));
+
+  // Detect unsaved changes (compare trimmed values to avoid whitespace-only diffs).
   useEffect(() => {
     if (!selectedTestCase) return;
-    const originalConv = JSON.stringify(selectedTestCase?.conversation || []);
-    const editedConv = JSON.stringify(editedConversation);
-    const originalExp = getExpectedValue(selectedTestCase);
-    setHasUnsavedChanges(originalConv !== editedConv || originalExp !== editedExpected);
+    const originalConv = JSON.stringify(trimConversation(selectedTestCase?.conversation || []));
+    const editedConv = JSON.stringify(trimConversation(editedConversation));
+    const originalExp = (getExpectedValue(selectedTestCase) || "").trim();
+    const editedExp = (editedExpected || "").trim();
+    setHasUnsavedChanges(originalConv !== editedConv || originalExp !== editedExp);
   }, [editedConversation, editedExpected, selectedTestCase]);
 
   const handleConversationChange = (idx, newContent) => {
     setEditedConversation((prev) => prev.map((m, i) => (i === idx ? { ...m, content: newContent } : m)));
   };
 
+  const handleConversationBlur = (idx) => {
+    setEditedConversation((prev) =>
+      prev.map((m, i) => {
+        if (i !== idx) return m;
+        if (typeof m?.content !== "string") return m;
+        const trimmed = m.content.trim();
+        return trimmed === m.content ? m : { ...m, content: trimmed };
+      })
+    );
+    if (hasUnsavedChanges) handleSaveChanges();
+  };
+
+  const handleExpectedBlur = () => {
+    const trimmed = (editedExpected || "").trim();
+    if (trimmed !== editedExpected) setEditedExpected(trimmed);
+    if (hasUnsavedChanges) handleSaveChanges();
+  };
+
   const handleSaveChanges = async () => {
+    const trimmedConversation = trimConversation(editedConversation);
+    const trimmedExpected = (editedExpected || "").trim();
+
+    const originalConv = JSON.stringify(trimConversation(selectedTestCase?.conversation || []));
+    const editedConv = JSON.stringify(trimmedConversation);
+    const originalExp = (getExpectedValue(selectedTestCase) || "").trim();
+    if (originalConv === editedConv && originalExp === trimmedExpected) {
+      setHasUnsavedChanges(false);
+      return;
+    }
+
     const isToolCallType = selectedTestCase?.type === "function" || selectedTestCase?.expected?.tool_calls;
     let updatedExpected;
     if (isToolCallType) {
       try {
-        updatedExpected = { tool_calls: JSON.parse(editedExpected) };
+        updatedExpected = { tool_calls: JSON.parse(trimmedExpected) };
       } catch {
-        updatedExpected = { response: editedExpected };
+        updatedExpected = { response: trimmedExpected };
       }
     } else {
-      updatedExpected = { response: editedExpected };
+      updatedExpected = { response: trimmedExpected };
     }
+
+    // Reflect trimmed values locally so the inputs don't keep stale whitespace.
+    setEditedConversation(trimmedConversation);
+    setEditedExpected(trimmedExpected);
 
     await dispatch(
       updateTestCaseAction({
         testCaseId: selectedTestCase?._id,
         dataToUpdate: {
-          conversation: editedConversation,
+          conversation: trimmedConversation,
           type: selectedTestCase?.type,
           expected: updatedExpected,
           matching_type: selectedTestCase?.matching_type,
@@ -225,7 +269,9 @@ const TestCaseDetailsPanel = ({
     setVersionVariables(mergedVersionVariables);
   }, [selectedVersions, bridgeVersionMapping, dispatch]);
 
-  // Function to merge variables intelligently
+  // Function to merge variables intelligently. `pre_function` is an
+  // internal/system-managed variable; exclude it from the user-facing merged
+  // set so it doesn't trigger the empty-variables alert or get sent on run.
   const getMergedVariables = () => {
     const merged = {};
 
@@ -233,6 +279,7 @@ const TestCaseDetailsPanel = ({
     Object.entries(versionVariables || {}).forEach(([versionId, versionVars]) => {
       if (typeof versionVars === "object" && versionVars !== null) {
         Object.entries(versionVars).forEach(([key, varData]) => {
+          if (key === "pre_function") return;
           // Use test case value if available, otherwise use version value
           merged[key] = testCaseVariables[key] || varData?.value || "";
         });
@@ -241,6 +288,7 @@ const TestCaseDetailsPanel = ({
 
     // Add any test case variables that aren't in version variables
     Object.entries(testCaseVariables || {}).forEach(([key, value]) => {
+      if (key === "pre_function") return;
       if (!merged[key]) {
         merged[key] = value;
       }
@@ -446,9 +494,7 @@ const TestCaseDetailsPanel = ({
                             <AutoResizeTextarea
                               value={message?.content || ""}
                               onChange={(e) => handleConversationChange(idx, e.target.value)}
-                              onBlur={() => {
-                                if (hasUnsavedChanges) handleSaveChanges();
-                              }}
+                              onBlur={() => handleConversationBlur(idx)}
                               className="w-full bg-transparent text-sm text-base-content leading-relaxed outline-none border-0 focus:ring-1 focus:ring-primary/30 rounded p-1"
                             />
                           ) : (
@@ -480,9 +526,7 @@ const TestCaseDetailsPanel = ({
                   <AutoResizeTextarea
                     value={typeof lastUserContent === "string" ? lastUserContent : JSON.stringify(lastUserContent)}
                     onChange={(e) => handleConversationChange(lastUserIdx, e.target.value)}
-                    onBlur={() => {
-                      if (hasUnsavedChanges) handleSaveChanges();
-                    }}
+                    onBlur={() => handleConversationBlur(lastUserIdx)}
                     className="w-full bg-transparent text-sm text-base-content leading-relaxed outline-none"
                   />
                 </div>
@@ -500,33 +544,12 @@ const TestCaseDetailsPanel = ({
               <AutoResizeTextarea
                 value={editedExpected}
                 onChange={(e) => setEditedExpected(e.target.value)}
-                onBlur={() => {
-                  if (hasUnsavedChanges) handleSaveChanges();
-                }}
+                onBlur={handleExpectedBlur}
                 minRows={2}
                 className="w-full bg-transparent text-sm text-base-content leading-relaxed outline-none"
               />
             </div>
           </div>
-
-          {/* Variables Response */}
-          {selectedTestCase?.variables && Object.keys(selectedTestCase.variables).length > 0 && (
-            <div className="mb-6">
-              <div className="text-xs font-semibold text-base-content/70 mb-2 uppercase tracking-wide">Variables</div>
-              <div className="bg-base-50 rounded-lg px-4 py-3 border border-base-200 space-y-2">
-                {Object.entries(selectedTestCase.variables).map(([key, value]) => (
-                  <div
-                    key={key}
-                    className="flex items-center justify-between py-1.5 px-2 bg-base-100 rounded border border-base-200"
-                  >
-                    <span className="text-sm font-medium text-base-content">{key}:</span>
-                    <span className="text-sm text-base-content/70">{String(value)}</span>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
           {/* Version Comparison (independent of run-version selection) */}
           <div ref={dropdownRef}>
             <div className="mb-5 flex items-center gap-2 flex-wrap">
@@ -620,7 +643,10 @@ const TestCaseDetailsPanel = ({
                               Error
                             </span>
                           ) : (
-                            <span className={`text-lg font-bold ${getScoreColor(score, matchingTypeFromResult)}`}>
+                            <span
+                              className={`text-lg font-bold cursor-help ${getScoreColor(score, matchingTypeFromResult)}`}
+                              title={getScoreMessage(score, matchingTypeFromResult)}
+                            >
                               {getScoreDisplay(score, matchingTypeFromResult)}
                             </span>
                           )}
@@ -635,32 +661,6 @@ const TestCaseDetailsPanel = ({
                       ) : (
                         <div className="text-sm text-base-content leading-relaxed mb-3">
                           {typeof modelOutput === "string" ? modelOutput : JSON.stringify(modelOutput)}
-                        </div>
-                      )}
-
-                      {/* Variables Response */}
-                      {selectedTestCase?.variables && Object.keys(selectedTestCase.variables).length > 0 && (
-                        <div className="pt-3 border-t border-base-200">
-                          <div className="text-xs font-semibold text-base-content/60 mb-2 uppercase tracking-wide">
-                            Variables Response
-                          </div>
-                          <div className="space-y-1.5">
-                            {Object.entries(selectedTestCase.variables).map(([key, value]) => {
-                              const variableResult =
-                                versionArray?.[versionArray?.length - 1]?.variables_response?.[key];
-                              const variableScore = variableResult?.score || 0;
-                              const matchingType = selectedTestCase?.matching_type || "cosine";
-                              const displayValue = getScoreDisplay(variableScore, matchingType);
-                              const colorClass = getScoreColor(variableScore, matchingType);
-
-                              return (
-                                <div key={key} className="flex items-center justify-between text-xs">
-                                  <span className="text-base-content/70">{key}:</span>
-                                  <span className={`font-semibold ${colorClass}`}>{displayValue}</span>
-                                </div>
-                              );
-                            })}
-                          </div>
                         </div>
                       )}
                     </div>

--- a/components/testcaseComponents/TestCaseVariablesModal.js
+++ b/components/testcaseComponents/TestCaseVariablesModal.js
@@ -14,12 +14,12 @@ const TestCaseVariablesModal = ({
 }) => {
   const [editableVariables, setEditableVariables] = useState({});
 
-  // Compute merged source variables (stable as long as inputs don't change)
   const mergedSource = useMemo(() => {
     const merged = {};
     Object.entries(versionVariables || {}).forEach(([, versionVars]) => {
       if (typeof versionVars === "object" && versionVars !== null) {
         Object.entries(versionVars).forEach(([key, varData]) => {
+          if (key === "pre_function") return;
           if (!(key in merged)) {
             merged[key] = varData?.value || "";
           }
@@ -27,6 +27,7 @@ const TestCaseVariablesModal = ({
       }
     });
     Object.entries(testCaseVariables || {}).forEach(([key, value]) => {
+      if (key === "pre_function") return;
       merged[key] = value ?? "";
     });
     return merged;
@@ -45,8 +46,38 @@ const TestCaseVariablesModal = ({
     }));
   };
 
+  const handleVariableBlur = (key) => {
+    setEditableVariables((prev) => {
+      const current = prev[key];
+      if (typeof current !== "string") return prev;
+      const trimmed = current.trim();
+      if (trimmed === current) return prev;
+      return { ...prev, [key]: trimmed };
+    });
+  };
+
+  // Build the trimmed payload that will be saved
+  const trimmedVariables = useMemo(() => {
+    const out = {};
+    Object.entries(editableVariables).forEach(([key, value]) => {
+      out[key] = typeof value === "string" ? value.trim() : value;
+    });
+    return out;
+  }, [editableVariables]);
+
+  // Detect whether anything actually changed vs. the merged source
+  const isDirty = useMemo(() => {
+    const sourceKeys = Object.keys(mergedSource || {});
+    const editedKeys = Object.keys(trimmedVariables || {});
+    if (sourceKeys.length !== editedKeys.length) return true;
+    return editedKeys.some((key) => {
+      const sourceVal = typeof mergedSource[key] === "string" ? mergedSource[key].trim() : mergedSource[key];
+      return trimmedVariables[key] !== sourceVal;
+    });
+  }, [trimmedVariables, mergedSource]);
+
   const handleSave = () => {
-    onSave(editableVariables);
+    onSave(trimmedVariables);
     closeModal(MODAL_TYPE.TEST_CASE_VARIABLES_MODAL);
   };
 
@@ -99,6 +130,7 @@ const TestCaseVariablesModal = ({
                         <AutoResizeTextarea
                           value={typeof value === "string" ? value : JSON.stringify(value)}
                           onChange={(e) => handleVariableChange(key, e.target.value)}
+                          onBlur={() => handleVariableBlur(key)}
                           placeholder="Enter value"
                           className="textarea textarea-bordered textarea-sm bg-base-100 text-sm w-full leading-relaxed"
                         />
@@ -126,7 +158,7 @@ const TestCaseVariablesModal = ({
                 </button>
               )}
             {Object.keys(editableVariables).length > 0 && (
-              <button onClick={handleSave} className="btn btn-primary btn-sm">
+              <button onClick={handleSave} disabled={!isDirty} className="btn btn-primary btn-sm">
                 Save Variables
               </button>
             )}

--- a/config/testCaseApi.js
+++ b/config/testCaseApi.js
@@ -64,7 +64,7 @@ export const runTestCaseApi = async ({ versionIds, testcase_id, testCaseData, br
       error?.response?.data?.detail?.error ? error?.response?.data?.detail?.error : "Error while running the testcases"
     );
     console.error(error);
-    return error;
+    throw error;
   }
 };
 

--- a/store/reducer/testCasesReducer.js
+++ b/store/reducer/testCasesReducer.js
@@ -76,8 +76,17 @@ const testCasesReducer = createSlice({
       if (bridgeId && state.testCases[bridgeId]) {
         const index = state.testCases[bridgeId].findIndex((testCase) => testCase._id === testCaseId);
         if (index !== -1) {
-          // Update the test case with new data while preserving the _id
-          state.testCases[bridgeId][index] = dataToUpdate;
+          // Update the test case with new data while preserving fields the
+          // backend response doesn't echo back (version_history, execution).
+          // Otherwise the previously cached per-version run results would be
+          // wiped from the UI on every edit until a page refresh re-fetches.
+          const existing = state.testCases[bridgeId][index] || {};
+          state.testCases[bridgeId][index] = {
+            ...existing,
+            ...dataToUpdate,
+            version_history: dataToUpdate?.version_history ?? existing.version_history,
+            execution: dataToUpdate?.execution ?? existing.execution,
+          };
         }
       }
       return state;


### PR DESCRIPTION
…eserve run results on edit

- Change table to border-separate to fix sticky column borders
- Use inline styles for sticky column positioning to ensure consistent layout
- Add tooltip with score interpretation on hover for Pass/Fail and percentage scores
- Update AI matching type to display percentage instead of Pass/Fail
- Trim whitespace from conversation and expected values on blur and save
- Skip API call when re-selecting the same matching