### PR TITLE
refactor: show only tools_data response in history

### DIFF
--- a/components/historyPageComponents/ToolsDataModal.js
+++ b/components/historyPageComponents/ToolsDataModal.js
@@ -33,11 +33,15 @@ const ToolsDataModal = ({ toolsData, handleClose, toolsDataModalRef, integration
               <div className="mt-4">
                 {Object.entries(toolsData || {})?.map(([key, value], index) => (
                   <div key={index} className="flex items-start gap-2 mb-2">
-                    <span className="w-28 shrink-0 capitalize">{key}:</span>
+                    <span className="w-28 shrink-0 capitalize">{key === "data" ? "response" : key}:</span>
                     <span className="flex-1 min-w-0">
                       {key === "name" && integrationData?.[value] ? (
                         <pre className="text-sm bg-base-200 p-2 rounded whitespace-pre-wrap break-all">
                           {integrationData[value]?.title}
+                        </pre>
+                      ) : key === "data" && value?.response !== undefined ? (
+                        <pre className="text-sm bg-base-200 p-2 rounded whitespace-pre-wrap break-all">
+                          {formatValue(value.response)}
                         </pre>
                       ) : (
                         <pre className="text-sm bg-base-200 p-2 rounded whitespace-pre-wrap break-all">


### PR DESCRIPTION
Updated the history view to display only the response content from tools_data.

Changes
- Removed status from the displayed tools_data.
- Removed metadata from the displayed tools_data.
- Retained only the response field for rendering tool outputs in history.
- Simplified the history payload display and reduced unnecessary information shown to users.