### PR TITLE
fix: pin wrangler to 4.107.1 so fresh npm install resolves

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,9 @@
     "prettier": "^3.8.0",
     "tailwindcss": "3.4.19"
   },
+  "overrides": {
+    "wrangler": "4.107.1"
+  },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
       "prettier --write",


### PR DESCRIPTION
Fresh npm install fails with ERESOLVE (see #2084): next-on-pages needs workers-types@^4, but its unpinned wrangler peer now resolves to 4.108.0+, which requires ^5. This pins wrangler to 4.107.1 — the last version compatible with workers-types@^4 — via npm overrides.

Before: npm install on a clean clone exits with ERESOLVE.

After: npm install succeeds with no flags; npm run dev boots and serves normally.

Tested: deleted node_modules, ran npm install (no flags), confirmed npm ls wrangler shows 4.107.1 via the override, ran npm run dev and loaded / and /login. wrangler is only used by the build:pages path, so dev/build behavior is unchanged.

Closes #2084 