### PR TITLE
fix: remove unused deleteWarning prop

### DIFF
--- a/components/configuration/configurationComponent/PostEmbedList.js
+++ b/components/configuration/configurationComponent/PostEmbedList.js
@@ -192,7 +192,6 @@ const PostEmbedList = ({ params, searchParams, isPublished, isEditor = true, isE
           modalType={MODAL_TYPE.DELETE_POST_TOOL_MODAL}
           loading={isDeleting}
           isAsync={true}
-          warning={deleteWarning}
         />
 
         <div


### PR DESCRIPTION
- Remove unused `warning` prop from delete modal component
- Simplifies modal configuration by eliminating unnecessary state
- Improves component maintainability