### PR TITLE
refactor: if main model is selected same as fallback model then also …

### DIFF
--- a/components/configuration/configurationComponent/FallbackModel.js
+++ b/components/configuration/configurationComponent/FallbackModel.js
@@ -277,8 +277,6 @@ const FallbackModel = ({
         const optionConfig = options?.[optionKey];
         const modelName = optionConfig?.configuration?.model?.default || optionKey;
 
-        if (currentModel === modelName || currentModel === optionKey) return;
-
         const serviceConfig = embedModelsConfig?.[fallbackService];
         const modelConfig = serviceConfig?.[modelName];
         if (modelConfig?.hide === true) return;
@@ -294,7 +292,7 @@ const FallbackModel = ({
       });
     });
     return opts;
-  }, [computedModelsList, currentModel, embedModelsConfig, fallbackService]);
+  }, [computedModelsList, embedModelsConfig, fallbackService]);
 
   const fallbackServiceOptions = useMemo(() => {
     if (!Array.isArray(SERVICES)) return [];


### PR DESCRIPTION
Fallback model stays visible in the dropdown even if it matches the main model
Existing warning still shows: “This model is already selected please change the model”
Nothing else (save/toggle/API) was changed