### PR TITLE
 Metrics dashboard 

### DIFF
--- a/app/org/[org_id]/agents/page.js
+++ b/app/org/[org_id]/agents/page.js
@@ -1196,6 +1196,18 @@ function Home({ params, searchParams, isEmbedUser }) {
               </div>
             ) : null}
           </div>
+          <div className="opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+            <button
+              className="btn btn-outline btn-ghost btn-sm"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                router.push(`/org/${resolvedParams.org_id}/metrics?bridge_ids=${row._id}&factor=0`);
+              }}
+            >
+              Metrics
+            </button>
+          </div>
           {(isEditor || (isEmbedUser && showDeleteAgentOption)) && (
             <div className="bg-transparent">
               <div

--- a/app/org/[org_id]/apikeys/page.js
+++ b/app/org/[org_id]/apikeys/page.js
@@ -16,14 +16,14 @@ import {
   toggleSidebar,
   getApiKeyStatusClass,
 } from "@/utils/utility";
-import { BookIcon, RefreshIcon, SquarePenIcon, TrashIcon } from "@/components/Icons";
+import { BookIcon, ChartIcon, RefreshIcon, SquarePenIcon, TrashIcon } from "@/components/Icons";
 import ResourcePage from "@/components/folders/ResourcePage";
 import FolderTabs from "@/components/folders/FolderTabs";
 import MoveToFolderMenu from "@/components/folders/MoveToFolderMenu";
 import useFolders from "@/hooks/useFolders";
 import { useFolderContext } from "@/components/folders/FolderContext";
 import { Folder } from "lucide-react";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useDispatch } from "react-redux";
 import DeleteModal from "@/components/UI/DeleteModal";
@@ -37,6 +37,7 @@ export const runtime = "edge";
 
 const Page = ({ isEmbedUser = false }) => {
   const pathName = usePathname();
+  const router = useRouter();
   const dispatch = useDispatch();
   const path = pathName?.split("?")[0].split("/");
   const orgId = path[2] || "";
@@ -181,6 +182,16 @@ const Page = ({ isEmbedUser = false }) => {
   const EndComponent = ({ row }) => {
     return (
       <div className="flex gap-3 justify-center items-center" onClick={(e) => e.stopPropagation()}>
+        <div
+          className="tooltip tooltip-primary"
+          data-tip="View Metrics"
+          onClick={(e) => {
+            e.stopPropagation();
+            router.push(`/org/${orgId}/metrics?apikey_ids=${row._id}&factor=1`);
+          }}
+        >
+          <ChartIcon size={16} />
+        </div>
         <div
           className="tooltip tooltip-primary"
           data-tip="delete"

--- a/app/org/[org_id]/metrics/page.js
+++ b/app/org/[org_id]/metrics/page.js
@@ -1,22 +1,41 @@
 "use client";
-import { use, useEffect, useState } from "react";
-import { TIME_RANGE_OPTIONS } from "@/utils/enums";
+import { use, useEffect, useState, useMemo } from "react";
 import Protected from "@/components/Protected";
 import { useCustomSelector } from "@/customHooks/customSelector";
 import { useSearchParams } from "next/navigation";
 
 // Custom hooks
 import { useMetricsData } from "@/customHooks/useMetricsData";
+import { useRequestActivity } from "@/customHooks/useRequestActivity";
 import { useMetricsURL } from "@/customHooks/useMetricsURL";
 import { useThemeManager } from "@/customHooks/useThemeManager";
+import { METRICS_TIME_RANGE_OPTIONS } from "@/utils/enums";
 
 // Components
-import DateRangePicker from "@/components/metrics/DateRangePicker";
 import MetricsFilters from "@/components/metrics/MetricsFilters";
 import MetricsChart from "@/components/metrics/MetricsChart";
+import RequestActivityCard from "@/components/metrics/RequestActivityCard";
 import TokenUsageOverview from "@/components/metrics/TokenUsageOverview";
 
 export const runtime = "edge";
+
+// Range codes supported by the dashboard - kept in sync with
+// METRICS_TIME_RANGE_OPTIONS itself (single source of truth) rather than a
+// separately hand-maintained list, so a new preset added there is
+// automatically accepted from the URL without a second edit here.
+const RANGE_CODES = METRICS_TIME_RANGE_OPTIONS.map((option) => option.range);
+const DEFAULT_RANGE = 6;
+const CUSTOM_RANGE = 10;
+
+const parseValidDate = (value) => {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+// Multi-select filters are persisted as comma-joined ids in the URL.
+const parseIdList = (value) => (value ? value.split(",").filter(Boolean) : []);
+const toParam = (list) => (list && list.length ? list.join(",") : null);
 
 function Page({ params }) {
   const resolvedParams = use(params);
@@ -25,36 +44,100 @@ function Page({ params }) {
 
   // State management
   const [factor, setFactor] = useState(parseInt(searchParams.get("factor")) || 0);
-  const [range, setRange] = useState(parseInt(searchParams.get("range")) || 0);
-  const [customStartDate, setCustomStartDate] = useState(searchParams.get("start_date") || null);
-  const [customEndDate, setCustomEndDate] = useState(searchParams.get("end_date") || null);
-  const [isDatePickerOpen, setIsDatePickerOpen] = useState(false);
-  const [bridge, setBridge] = useState(() => {
-    const bridgeId = searchParams.get("bridge_id");
-    const bridgeName = searchParams.get("bridge_name");
-    return bridgeId && bridgeName ? { bridge_id: bridgeId, bridge_name: bridgeName } : null;
+  const [customStartDate, setCustomStartDate] = useState(() => parseValidDate(searchParams.get("start_date")));
+  const [customEndDate, setCustomEndDate] = useState(() => parseValidDate(searchParams.get("end_date")));
+  const [range, setRange] = useState(() => {
+    const value = parseInt(searchParams.get("range"));
+    if (!RANGE_CODES.includes(value)) return DEFAULT_RANGE;
+    if (value === CUSTOM_RANGE) {
+      const hasValidDates =
+        parseValidDate(searchParams.get("start_date")) && parseValidDate(searchParams.get("end_date"));
+      return hasValidDates ? value : DEFAULT_RANGE;
+    }
+    return value;
   });
-  const [filterBridges, setFilterBridges] = useState([]);
+  // Multi-select filters: each is an array of ids. An empty array means "All".
+  const [selectedBridgeIds, setSelectedBridgeIds] = useState(() => parseIdList(searchParams.get("bridge_ids")));
+  const [selectedApikeyIds, setSelectedApikeyIds] = useState(() => parseIdList(searchParams.get("apikey_ids")));
+  const [selectedModels, setSelectedModels] = useState(() => parseIdList(searchParams.get("models")));
+  const [selectedServices, setSelectedServices] = useState(() => parseIdList(searchParams.get("services")));
+  const [refreshNonce, setRefreshNonce] = useState(0);
 
   // Custom hooks
-  const { allBridges, apikeyData, descriptions } = useCustomSelector((state) => ({
+  const { allBridges, apikeyData, services } = useCustomSelector((state) => ({
     allBridges: state.bridgeReducer.org[orgId]?.orgs || [],
     apikeyData: state?.apiKeysReducer?.apikeys?.[orgId] || [],
-    descriptions: state.flowDataReducer?.flowData?.descriptionsData?.descriptions || {},
+    services: state?.serviceReducer?.services || [],
   }));
 
-  const { rawData, loading, fetchMetricsData } = useMetricsData(orgId, allBridges, apikeyData);
-  const { updateURLParams, getDisplayRangeText } = useMetricsURL();
+  // allBridges (from the agent-list API) already excludes embed agents by
+  // construction (they're created under a different user_id context even
+  // though they share the org, and intentionally don't belong in the main
+  // Agents list/Metrics) - it still carries soft-deleted/archived agents with
+  // no filtering applied. "Total Agents" (and the Agent filter) now covers
+  // BOTH real agent types together - regular API agents and chatbots - since
+  // both are genuinely active agents in the org; only the soft-deleted/
+  // archived exclusion (agents/page.js filteredUnArchivedBridges) still
+  // applies here, matching the real Agents page's own visibility definition.
+  const visibleBridges = useMemo(
+    () => allBridges.filter((b) => (b.status === 1 || b.status === undefined) && !b.deletedAt),
+    [allBridges]
+  );
+
+  const isChatbot = (b) => (b.bridgeType || "").toLowerCase() === "chatbot";
+  const apiAgentCount = useMemo(() => visibleBridges.filter((b) => !isChatbot(b)).length, [visibleBridges]);
+  const chatbotCount = useMemo(() => visibleBridges.filter(isChatbot).length, [visibleBridges]);
+
+  const { rawData, modelOptions, agentModelBreakdown, loading, headlineStats, fetchMetricsData } = useMetricsData(
+    orgId,
+    allBridges,
+    apikeyData,
+    services
+  );
+  const {
+    data: requestActivityData,
+    agentTokenBreakdown,
+    loading: requestActivityLoading,
+    fetchRequestActivity,
+  } = useRequestActivity();
+  const { updateURLParams } = useMetricsURL();
   const { actualTheme } = useThemeManager();
 
   // Effects
   useEffect(() => {
-    setFilterBridges(allBridges);
-  }, [allBridges]);
+    fetchMetricsData({
+      factor,
+      range,
+      bridge: selectedBridgeIds,
+      apikey: selectedApikeyIds,
+      model: selectedModels,
+      service: selectedServices,
+      customStartDate,
+      customEndDate,
+    });
+    fetchRequestActivity({
+      range,
+      bridge: selectedBridgeIds,
+      model: selectedModels,
+      service: selectedServices,
+      customStartDate,
+      customEndDate,
+    });
+  }, [
+    factor,
+    range,
+    selectedBridgeIds,
+    selectedApikeyIds,
+    selectedModels,
+    selectedServices,
+    customStartDate,
+    customEndDate,
+    refreshNonce,
+    fetchMetricsData,
+    fetchRequestActivity,
+  ]);
 
-  useEffect(() => {
-    fetchMetricsData(factor, range, bridge, customStartDate, customEndDate);
-  }, [factor, range, bridge, customStartDate, customEndDate, fetchMetricsData]);
+  const handleRefresh = () => setRefreshNonce((n) => n + 1);
 
   // Event handlers
   const handleFactorChange = (index) => {
@@ -62,88 +145,145 @@ function Page({ params }) {
     updateURLParams({ factor: index });
   };
 
-  const handleTimeRangeChange = (index) => {
-    if (index === TIME_RANGE_OPTIONS.length) {
-      setIsDatePickerOpen(true);
-    } else {
-      setRange(index);
-      setCustomStartDate(null);
-      setCustomEndDate(null);
-      updateURLParams({
-        range: index,
-        start_date: null,
-        end_date: null,
-      });
-    }
+  const handleTimeRangeChange = (rangeCode) => {
+    setRange(rangeCode);
+    setCustomStartDate(null);
+    setCustomEndDate(null);
+    updateURLParams({ range: rangeCode, start_date: null, end_date: null });
   };
 
-  const handleDateRangeSelect = (startDate, endDate) => {
+  const handleCustomRangeApply = (startDate, endDate) => {
+    setRange(CUSTOM_RANGE);
     setCustomStartDate(startDate);
     setCustomEndDate(endDate);
-    setRange(10);
     updateURLParams({
-      range: 10,
-      start_date: startDate,
-      end_date: endDate,
+      range: CUSTOM_RANGE,
+      start_date: startDate.toISOString().slice(0, 10),
+      end_date: endDate.toISOString().slice(0, 10),
     });
   };
 
-  const handleBridgeChange = (bridge_id, bridge_name) => {
-    const newBridge = bridge_id && bridge_name ? { bridge_id, bridge_name } : null;
-    setBridge(newBridge);
-    updateURLParams({
-      bridge_id: bridge_id,
-      bridge_name: bridge_name,
-    });
+  const handleBridgeChange = (ids) => {
+    setSelectedBridgeIds(ids);
+    updateURLParams({ bridge_ids: toParam(ids) });
+  };
+
+  const handleApikeyChange = (ids) => {
+    setSelectedApikeyIds(ids);
+    updateURLParams({ apikey_ids: toParam(ids) });
+  };
+
+  const handleModelChange = (ids) => {
+    setSelectedModels(ids);
+    updateURLParams({ models: toParam(ids) });
+  };
+
+  const handleServiceChange = (ids) => {
+    setSelectedServices(ids);
+    updateURLParams({ services: toParam(ids) });
   };
 
   return (
     <div className="p-10 min-h-screen">
       {/* Page Header */}
       <header className="mb-8" data-testid="metrics-dashboard-header">
-        <h1 className="text-3xl font-bold text-base-content">Metrics Dashboard</h1>
-        <p className="text-base-content">
-          {descriptions?.["Metrics"] || "Monitor your application's key metrics at a glance."}
-        </p>
+        <h1 className="text-3xl font-bold text-base-content">Metrics</h1>
       </header>
 
       {/* Filters */}
       <MetricsFilters
-        factor={factor}
         range={range}
-        bridge={bridge}
-        loading={loading}
-        filterBridges={filterBridges}
-        setFilterBridges={setFilterBridges}
-        allBridges={allBridges}
         customStartDate={customStartDate}
         customEndDate={customEndDate}
-        onFactorChange={handleFactorChange}
-        onTimeRangeChange={handleTimeRangeChange}
+        selectedBridgeIds={selectedBridgeIds}
+        selectedApikeyIds={selectedApikeyIds}
+        selectedModels={selectedModels}
+        selectedServices={selectedServices}
+        allBridges={visibleBridges}
+        apikeyData={apikeyData}
+        modelOptions={modelOptions}
+        services={services}
+        loading={loading || requestActivityLoading}
         onBridgeChange={handleBridgeChange}
-        getDisplayRangeText={() => getDisplayRangeText(range, customStartDate, customEndDate, TIME_RANGE_OPTIONS)}
+        onApikeyChange={handleApikeyChange}
+        onModelChange={handleModelChange}
+        onServiceChange={handleServiceChange}
+        onTimeRangeChange={handleTimeRangeChange}
+        onCustomRangeApply={handleCustomRangeApply}
+        onRefresh={handleRefresh}
+        exportProps={{
+          orgId,
+          factor,
+          range,
+          customStartDate,
+          customEndDate,
+          selectedBridgeIds,
+          selectedApikeyIds,
+          selectedModels,
+          selectedServices,
+          allBridges,
+          apikeyData,
+          services,
+        }}
       />
 
-      {/* Date Range Picker Modal */}
-      <DateRangePicker
-        isOpen={isDatePickerOpen}
-        onClose={() => setIsDatePickerOpen(false)}
-        onDateRangeSelect={handleDateRangeSelect}
-        initialStartDate={customStartDate}
-        initialEndDate={customEndDate}
-      />
+      {/* Main grid: chart on the left, Agents count + Request Activity in the sidebar */}
+      <div className="grid grid-cols-1 xl:grid-cols-[1fr_360px] gap-4 items-stretch">
+        <div className="bg-base-100 shadow-md rounded-lg p-6 min-w-0" data-testid="metrics-visualization-container">
+          <MetricsChart
+            rawData={rawData}
+            currentTheme={actualTheme}
+            factor={factor}
+            range={range}
+            onFactorChange={handleFactorChange}
+            headlineStats={headlineStats}
+            loading={loading}
+          />
+        </div>
 
-      {/* Charts Section */}
-      <div className="bg-base-100 shadow-md rounded-lg p-6 mb-6" data-testid="metrics-visualization-container">
-        <h2 className="text-lg font-bold mb-4">Metrics Visualization</h2>
-        <div className="h-96" data-testid="metrics-chart-wrapper">
-          <MetricsChart rawData={rawData} currentTheme={actualTheme} factor={factor} />
+        <div className="flex flex-col gap-4 h-full">
+          <div className="bg-base-100 shadow-md rounded-lg p-4">
+            <div className="flex items-center justify-between">
+              <span className="text-[11px] font-semibold tracking-wide text-base-content/50 uppercase">
+                Total Agents
+              </span>
+              <span className="text-xl font-bold text-base-content">{visibleBridges.length}</span>
+            </div>
+            <div className="flex items-center justify-between mt-2 pt-2 border-t border-base-300">
+              <span className="text-[11px] text-base-content/50">API Agents</span>
+              <span className="text-sm font-semibold text-base-content">{apiAgentCount}</span>
+            </div>
+            <div className="flex items-center justify-between mt-1">
+              <span className="text-[11px] text-base-content/50">Chatbots</span>
+              <span className="text-sm font-semibold text-base-content">{chatbotCount}</span>
+            </div>
+            <div className="flex items-center justify-between mt-2 pt-2 border-t border-base-300">
+              <span className="text-[11px] text-base-content/50">Active</span>
+              <span className="text-sm font-semibold text-base-content">
+                {visibleBridges.filter((b) => b.bridge_status !== 0).length}
+              </span>
+            </div>
+            <div className="flex items-center justify-between mt-1">
+              <span className="text-[11px] text-base-content/50">Paused</span>
+              <span className="text-sm font-semibold text-base-content">
+                {visibleBridges.filter((b) => b.bridge_status === 0).length}
+              </span>
+            </div>
+          </div>
+
+          {/* Real successful vs failed request activity, from conversation_logs */}
+          <RequestActivityCard data={requestActivityData} />
         </div>
       </div>
 
       {/* Token Usage Overview */}
-      <div data-testid="token-usage-overview-container">
-        <TokenUsageOverview rawData={rawData} />
+      <div data-testid="token-usage-overview-container" className="mt-4">
+        <TokenUsageOverview
+          rawData={rawData}
+          factor={factor}
+          agentModelBreakdown={agentModelBreakdown}
+          agentTokenBreakdown={agentTokenBreakdown}
+        />
       </div>
     </div>
   );

--- a/components/metrics/ExportMetricsButton.js
+++ b/components/metrics/ExportMetricsButton.js
@@ -1,0 +1,256 @@
+import { memo, useState, useEffect, useCallback } from "react";
+import { DownloadIcon, CloseIcon } from "@/components/Icons";
+import { getMetricsDataApi } from "@/config/index";
+import { aggregateMetricsByKey, computeCurrentWindow } from "@/customHooks/useMetricsData";
+import { METRICS_FACTOR_OPTIONS, METRICS_FACTOR_LABELS } from "@/utils/enums";
+
+const triggerDownload = (content, filename, mime) => {
+  const blob = new Blob([content], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};
+
+const toCsv = (rows) => {
+  if (!rows.length) return "";
+  const headers = Object.keys(rows[0]);
+  const escapeCell = (value) => {
+    const str = String(value ?? "");
+    return /[",\n]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str;
+  };
+  const lines = [headers.join(","), ...rows.map((row) => headers.map((h) => escapeCell(row[h])).join(","))];
+  return lines.join("\n");
+};
+
+const toDateInputValue = (date) => (date ? new Date(date).toISOString().slice(0, 10) : "");
+const asFilterValue = (value) => (Array.isArray(value) ? (value.length ? value : undefined) : value || undefined);
+
+const nameResolver =
+  (keyField, { allBridges, apikeyData, services }) =>
+  (id) => {
+    if (keyField === "bridge_id")
+      return allBridges.find((b) => b._id === id)?.name || `Agent ${String(id).slice(0, 6)}`;
+    if (keyField === "apikey_id")
+      return apikeyData.find((k) => k._id === id)?.name || `API Key ${String(id).slice(0, 6)}`;
+    if (keyField === "service") return services.find((s) => s?.value === id)?.displayName || id;
+    return id;
+  };
+
+// Export modal: "Group by" chooses which dimension to aggregate for the
+// export, defaulting to the page's current grouping. Both the group-by and
+// the date range are real, live controls - changing either fires a fresh
+// POST /api/metrics scoped to a custom range (using the SAME agent/model/
+// service/API-key filters currently active on the page), not a client-side
+// reshape of data already sitting in memory.
+const ExportMetricsButton = memo(
+  ({
+    orgId,
+    factor,
+    range,
+    customStartDate,
+    customEndDate,
+    selectedBridgeIds,
+    selectedApikeyIds,
+    selectedModels,
+    selectedServices,
+    allBridges = [],
+    apikeyData = [],
+    services = [],
+  }) => {
+    const [isOpen, setIsOpen] = useState(false);
+    // Defaults to the page's current grouping, but offers all four real
+    // dimensions - matching what the backend can actually group by, not an
+    // arbitrarily narrowed subset.
+    const [groupByKey, setGroupByKey] = useState(METRICS_FACTOR_OPTIONS[factor] || "bridge_id");
+    const [format, setFormat] = useState("csv");
+    const [nameFilter, setNameFilter] = useState("");
+    const [rows, setRows] = useState([]);
+    const [loading, setLoading] = useState(false);
+    const [dateRange, setDateRange] = useState(() => computeCurrentWindow(range, customStartDate, customEndDate));
+
+    // Reset to the page's current window/grouping whenever the modal is (re)opened.
+    useEffect(() => {
+      if (isOpen) {
+        setDateRange(computeCurrentWindow(range, customStartDate, customEndDate));
+        setGroupByKey(METRICS_FACTOR_OPTIONS[factor] || "bridge_id");
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isOpen]);
+
+    const runFetch = useCallback(async () => {
+      if (!dateRange.start || !dateRange.end) return;
+      setLoading(true);
+      try {
+        const requestBody = {
+          range: 10,
+          factor: groupByKey,
+          org_id: orgId,
+          start_date: dateRange.start,
+          end_date: dateRange.end,
+          bridge_id: asFilterValue(selectedBridgeIds),
+          apikey_id: asFilterValue(selectedApikeyIds),
+          model: asFilterValue(selectedModels),
+          service: asFilterValue(selectedServices),
+        };
+        const apiData = await getMetricsDataApi(requestBody);
+        setRows(
+          aggregateMetricsByKey(apiData, groupByKey, nameResolver(groupByKey, { allBridges, apikeyData, services }))
+        );
+      } catch (error) {
+        console.error("Error fetching export data:", error);
+        setRows([]);
+      } finally {
+        setLoading(false);
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [groupByKey, orgId, dateRange, selectedBridgeIds, selectedApikeyIds, selectedModels, selectedServices]);
+
+    useEffect(() => {
+      if (isOpen) runFetch();
+    }, [isOpen, runFetch]);
+
+    const filteredRows = nameFilter.trim()
+      ? rows.filter((row) =>
+          String(row.name || "")
+            .toLowerCase()
+            .includes(nameFilter.trim().toLowerCase())
+        )
+      : rows;
+
+    const handleDownload = () => {
+      const stamp = new Date().toISOString().slice(0, 10);
+      if (format === "json") {
+        triggerDownload(JSON.stringify(filteredRows, null, 2), `gateway-metrics-${stamp}.json`, "application/json");
+      } else {
+        triggerDownload(toCsv(filteredRows), `gateway-metrics-${stamp}.csv`, "text/csv");
+      }
+      setIsOpen(false);
+    };
+
+    return (
+      <>
+        <button
+          type="button"
+          title="Export"
+          onClick={() => setIsOpen(true)}
+          className="w-9 h-9 rounded-lg border border-base-300 bg-base-100 flex items-center justify-center text-base-content/70 hover:bg-base-200 hover:text-base-content transition-colors"
+        >
+          <DownloadIcon className="w-4 h-4" />
+        </button>
+
+        {isOpen && (
+          <div
+            className="fixed inset-0 z-high flex items-center justify-center bg-black/45 p-5"
+            onClick={() => setIsOpen(false)}
+          >
+            <div
+              className="w-full max-w-[460px] max-h-[90vh] overflow-y-auto bg-base-100 border border-base-300 rounded-lg shadow-2xl"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="flex items-center justify-between px-5 py-4 border-b border-base-300">
+                <h3 className="text-[15.5px] font-bold text-base-content">Export metrics</h3>
+                <button
+                  type="button"
+                  onClick={() => setIsOpen(false)}
+                  className="w-7 h-7 rounded-lg flex items-center justify-center text-base-content/70 hover:bg-base-200"
+                >
+                  <CloseIcon className="w-4 h-4" />
+                </button>
+              </div>
+
+              <div className="p-5 flex flex-col gap-3.5">
+                <div>
+                  <label className="text-[11.5px] font-semibold text-base-content/70 block mb-1.5">Group by</label>
+                  <select
+                    className="select select-sm w-full bg-base-200 border-base-300"
+                    value={groupByKey}
+                    onChange={(e) => setGroupByKey(e.target.value)}
+                  >
+                    {METRICS_FACTOR_OPTIONS.map((key, index) => (
+                      <option key={key} value={key}>
+                        {METRICS_FACTOR_LABELS[index]}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="grid grid-cols-2 gap-2.5">
+                  <div>
+                    <label className="text-[11.5px] font-semibold text-base-content/70 block mb-1.5">
+                      Filter by name
+                    </label>
+                    <input
+                      type="text"
+                      placeholder="All"
+                      value={nameFilter}
+                      onChange={(e) => setNameFilter(e.target.value)}
+                      className="input input-sm w-full bg-base-200 border-base-300"
+                    />
+                  </div>
+                  <div>
+                    <label className="text-[11.5px] font-semibold text-base-content/70 block mb-1.5">File format</label>
+                    <select
+                      className="select select-sm w-full bg-base-200 border-base-300"
+                      value={format}
+                      onChange={(e) => setFormat(e.target.value)}
+                    >
+                      <option value="csv">CSV</option>
+                      <option value="json">JSON</option>
+                    </select>
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-2 gap-2.5">
+                  <div>
+                    <label className="text-[11.5px] font-semibold text-base-content/70 block mb-1.5">Start date</label>
+                    <input
+                      type="date"
+                      value={toDateInputValue(dateRange.start)}
+                      max={toDateInputValue(dateRange.end)}
+                      onChange={(e) => setDateRange((prev) => ({ ...prev, start: new Date(e.target.value) }))}
+                      className="input input-sm w-full bg-base-200 border-base-300"
+                    />
+                  </div>
+                  <div>
+                    <label className="text-[11.5px] font-semibold text-base-content/70 block mb-1.5">End date</label>
+                    <input
+                      type="date"
+                      value={toDateInputValue(dateRange.end)}
+                      min={toDateInputValue(dateRange.start)}
+                      max={toDateInputValue(new Date())}
+                      onChange={(e) => setDateRange((prev) => ({ ...prev, end: new Date(e.target.value) }))}
+                      className="input input-sm w-full bg-base-200 border-base-300"
+                    />
+                  </div>
+                </div>
+
+                <button
+                  type="button"
+                  onClick={handleDownload}
+                  disabled={loading}
+                  className="btn btn-primary btn-sm w-full mt-1 gap-2"
+                >
+                  {loading ? (
+                    <span className="loading loading-spinner loading-xs"></span>
+                  ) : (
+                    <DownloadIcon className="w-4 h-4" />
+                  )}
+                  Export
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </>
+    );
+  }
+);
+
+ExportMetricsButton.displayName = "ExportMetricsButton";
+
+export default ExportMetricsButton;

--- a/components/metrics/MetricsChart.js
+++ b/components/metrics/MetricsChart.js
@@ -1,37 +1,192 @@
-import { memo } from "react";
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
+import { memo, useMemo, useState } from "react";
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ReferenceLine, ResponsiveContainer } from "recharts";
+import { METRICS_FACTOR_LABELS } from "@/utils/enums";
+import { ChevronDownIcon } from "@/components/Icons";
+import { formatTokens, formatCost, formatTokensFull, getMetricsColor } from "./metricsUtils";
 
-const MetricsChart = memo(({ rawData, currentTheme, factor }) => {
-  const FACTOR_OPTIONS = ["Bridges", "API Keys", "Models"];
+const OTHER_COLOR = "#9ca3af";
+const OTHER_KEY = "__other";
+const MAX_SERIES = 7;
 
-  const data = rawData.map((item) => ({
-    period: item.period,
-    totalCost: item.totalCost,
-    items: item.items,
-  }));
+const METRIC_OPTIONS = [
+  { key: "totalCost", itemField: "cost", label: "Cost", format: (v) => formatCost(v) },
+  { key: "totalTokens", itemField: "tokens", label: "Tokens", format: (v) => formatTokens(v) },
+  { key: "totalRequests", itemField: "successCount", label: "Requests", format: (v) => formatTokensFull(v) },
+];
+
+const closeDropdown = (event) => {
+  event.currentTarget.closest("details")?.removeAttribute("open");
+};
+
+const DeltaBadge = ({ deltaPct }) => {
+  if (deltaPct === null || deltaPct === undefined || !Number.isFinite(deltaPct)) return null;
+  const isUp = deltaPct >= 0;
+  return (
+    <div className={`text-xs font-semibold mt-1 ${isUp ? "text-success" : "text-error"}`}>
+      {isUp ? "+" : ""}
+      {deltaPct.toFixed(1)}% <span className="text-base-content/50 font-normal">vs previous period</span>
+    </div>
+  );
+};
+
+// Mirrors the real bucketing convertApiData applies per range (see
+// customHooks/useMetricsData.js): 15-minute buckets for the sub-2-day
+// presets, 1-day buckets for everything longer (including custom ranges,
+// which are always walked day-by-day). Compact form (e.g. "15m"/"1d") in a
+// small square badge, not a spelled-out "X buckets" pill.
+const getBucketLabel = (range) => (range <= 4 ? "15m" : "1d");
+
+const MetricsChart = memo(({ rawData, currentTheme, factor, range, onFactorChange, headlineStats, loading }) => {
+  const [hiddenIds, setHiddenIds] = useState(() => new Set());
+
+  // Fixed to Cost - the separate Cost/Tokens/Requests switcher was removed
+  // (redundant with the headline numbers above the chart).
+  const activeMetric = METRIC_OPTIONS[0];
+
+  // Top entities (by total value for the active metric, across the whole visible
+  // window) get their own stacked, individually-colored bar segment + legend
+  // chip; everything else outside that top set is folded into a single "Other"
+  // segment so the chart/legend stay readable regardless of how many agents/
+  // models/services are in the current view.
+  const topEntities = useMemo(() => {
+    const totals = new Map();
+    rawData.forEach((period) => {
+      (period.items || []).forEach((item) => {
+        const prev = totals.get(item.id) || { id: item.id, name: item.name, value: 0 };
+        prev.value += item[activeMetric.itemField] || 0;
+        totals.set(item.id, prev);
+      });
+    });
+    // Assigned by position (not a hash of the id) so every entity visible in
+    // the current view gets a genuinely distinct color - a hash-based
+    // assignment can collide or land two entities on near-identical hues.
+    return [...totals.values()]
+      .sort((a, b) => b.value - a.value)
+      .slice(0, MAX_SERIES)
+      .map((entry, index) => ({ ...entry, color: getMetricsColor(index) }));
+  }, [rawData, activeMetric.itemField]);
+
+  const topIds = useMemo(() => new Set(topEntities.map((e) => e.id)), [topEntities]);
+  const topColorById = useMemo(() => {
+    const map = new Map();
+    topEntities.forEach((entity) => map.set(entity.id, entity.color));
+    return map;
+  }, [topEntities]);
+  const colorForTooltipItem = (id) => topColorById.get(id) || OTHER_COLOR;
+
+  // Everything folded into "Other" - listed individually (with a scroller) in
+  // its own dropdown rather than being an opaque, all-or-nothing bucket.
+  const overflowEntities = useMemo(() => {
+    const totals = new Map();
+    rawData.forEach((period) => {
+      (period.items || []).forEach((item) => {
+        if (topIds.has(item.id)) return;
+        const prev = totals.get(item.id) || { id: item.id, name: item.name, value: 0 };
+        prev.value += item[activeMetric.itemField] || 0;
+        totals.set(item.id, prev);
+      });
+    });
+    return [...totals.values()].sort((a, b) => b.value - a.value);
+  }, [rawData, activeMetric.itemField, topIds]);
+
+  const [hiddenOverflowIds, setHiddenOverflowIds] = useState(() => new Set());
+
+  const data = useMemo(
+    () =>
+      rawData.map((period) => {
+        const items = period.items || [];
+        const row = {
+          period: period.period,
+          totalCost: period.totalCost,
+          totalTokens: items.reduce((sum, i) => sum + (i.tokens || 0), 0),
+          totalRequests: items.reduce((sum, i) => sum + (i.successCount || 0), 0),
+          items,
+        };
+        let otherValue = 0;
+        items.forEach((item) => {
+          const value = item[activeMetric.itemField] || 0;
+          if (topIds.has(item.id)) {
+            row[item.id] = hiddenIds.has(item.id) ? 0 : value;
+          } else if (!hiddenOverflowIds.has(item.id)) {
+            otherValue += value;
+          }
+        });
+        row[OTHER_KEY] = hiddenIds.has(OTHER_KEY) ? 0 : otherValue;
+        return row;
+      }),
+    [rawData, activeMetric.itemField, topIds, hiddenIds, hiddenOverflowIds]
+  );
+
+  const hasOther = useMemo(() => data.some((row) => row[OTHER_KEY] > 0), [data]);
+
+  const averageValue = useMemo(() => {
+    if (data.length === 0) return 0;
+    const sum = data.reduce((acc, row) => {
+      const visibleTotal = topEntities.reduce((s, e) => s + (row[e.id] || 0), 0) + (row[OTHER_KEY] || 0);
+      return acc + visibleTotal;
+    }, 0);
+    return sum / data.length;
+  }, [data, topEntities]);
+
+  const toggleLegend = (id) => {
+    setHiddenIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const toggleOverflow = (id) => {
+    setHiddenOverflowIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const groupByLabel = METRICS_FACTOR_LABELS[factor] || "Items";
 
   const CustomTooltip = ({ active, payload }) => {
     if (!active || !payload || !payload.length) return null;
     const point = payload[0].payload;
     return (
-      <div
-        className="bg-white p-4 shadow-xl min-w-[250px] max-w-[350px]"
-        style={{
-          fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
-        }}
-      >
-        <div className="text-base font-semibold text-black mb-3 text-center border-b border-gray-200 pb-2">
+      <div className="bg-base-100 p-4 shadow-xl rounded-lg border border-base-300 min-w-[250px] max-w-[360px]">
+        <div className="text-sm font-semibold text-base-content mb-3 text-center border-b border-base-200 pb-2">
           {point.period}
         </div>
-        <div className="text-sm font-semibold text-black mb-2">Total Cost: ${point.totalCost?.toFixed(3)}</div>
-        <div className="text-xs text-gray-500 mb-2">{FACTOR_OPTIONS[factor]} Breakdown:</div>
+        <div className="flex justify-between text-xs text-base-content/70 mb-2">
+          <span>Total Cost</span>
+          <span className="font-semibold text-base-content">${point.totalCost?.toFixed(3)}</span>
+        </div>
+        <div className="flex justify-between text-xs text-base-content/70 mb-2">
+          <span>Total Tokens</span>
+          <span className="font-semibold text-base-content">{formatTokensFull(point.totalTokens)}</span>
+        </div>
+        <div className="flex justify-between text-xs text-base-content/70 mb-2">
+          <span>Requests</span>
+          <span className="font-semibold text-base-content">{formatTokensFull(point.totalRequests)}</span>
+        </div>
+        <div className="text-xs font-medium text-base-content/60 mb-1.5">{groupByLabel} Breakdown:</div>
         <div className="space-y-1">
-          {point.items?.map((item) => (
-            <div key={item.name} className="flex justify-between items-center text-[11px] text-black">
-              <span className="flex-1 mr-2 truncate">{item.name}</span>
-              <span className="font-semibold min-w-[50px] text-right">${item.cost?.toFixed(3)}</span>
-            </div>
-          ))}
+          {point.items?.length > 0 ? (
+            point.items.map((item) => (
+              <div key={item.id} className="flex justify-between items-center text-[11px] text-base-content">
+                <span className="flex-1 mr-2 truncate flex items-center gap-1.5">
+                  <span
+                    className="w-1.5 h-1.5 rounded-sm flex-shrink-0"
+                    style={{ backgroundColor: colorForTooltipItem(item.id) }}
+                  />
+                  {item.name}
+                </span>
+                <span className="text-base-content/60 mr-3 flex-shrink-0">{formatTokens(item.tokens)} tokens</span>
+                <span className="font-semibold min-w-[50px] text-right flex-shrink-0">${item.cost?.toFixed(3)}</span>
+              </div>
+            ))
+          ) : (
+            <div className="text-[11px] text-base-content/50">No usage in this period</div>
+          )}
         </div>
       </div>
     );
@@ -39,6 +194,17 @@ const MetricsChart = memo(({ rawData, currentTheme, factor }) => {
 
   const axisColor = currentTheme === "dark" ? "oklch(var(--bc))" : "#374151";
   const gridColor = currentTheme === "dark" ? "oklch(var(--bc) / 0.2)" : "#e5e7eb";
+
+  if (loading && rawData.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="flex flex-col items-center gap-2">
+          <span className="loading loading-ring loading-lg"></span>
+          <div className="text-base-content/60 text-sm">Loading metrics...</div>
+        </div>
+      </div>
+    );
+  }
 
   if (rawData.length === 0) {
     return (
@@ -51,22 +217,90 @@ const MetricsChart = memo(({ rawData, currentTheme, factor }) => {
   }
 
   return (
-    <div
-      style={{
-        width: "100%",
-        overflowX: "auto",
-        overflowY: "hidden",
-      }}
-    >
-      <div
-        style={{
-          minWidth: Math.max(800, rawData.length * 60) + "px",
-          height: "400px",
-        }}
-      >
+    <div className="relative">
+      {/* Overlay (not a full replace) so filter changes show a spinner
+          without yanking the previous chart off-screen first - the old data
+          just dims underneath while the new request is in flight. */}
+      {loading && (
+        <div className="absolute inset-0 z-high flex items-center justify-center bg-base-100/60 rounded-lg">
+          <span className="loading loading-ring loading-lg"></span>
+        </div>
+      )}
+      <div className="flex flex-wrap items-start justify-between gap-6 mb-4">
+        <div>
+          <div className="flex items-center gap-1.5 text-xs font-semibold text-base-content/70 mb-2">
+            <span className="w-1.5 h-1.5 rounded-full bg-success shadow-[0_0_0_3px_var(--fallback-su,oklch(var(--su)/0.15))]"></span>
+            Cost and usage
+          </div>
+          <div className="flex items-baseline gap-8 flex-wrap">
+            <div>
+              <div className="text-2xl font-bold text-base-content leading-none">
+                {formatCost(headlineStats?.cost?.current)}
+              </div>
+              <div className="text-[11px] text-base-content/50 mt-1.5 font-semibold uppercase tracking-wide">
+                Total cost
+              </div>
+              <DeltaBadge deltaPct={headlineStats?.cost?.deltaPct} />
+            </div>
+            <div>
+              <div className="text-2xl font-bold text-base-content leading-none">
+                {formatTokensFull(headlineStats?.tokens?.current)}
+              </div>
+              <div className="text-[11px] text-base-content/50 mt-1.5 font-semibold uppercase tracking-wide">
+                Total tokens
+              </div>
+              <DeltaBadge deltaPct={headlineStats?.tokens?.deltaPct} />
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-col items-end gap-2 flex-shrink-0">
+          <details className="dropdown dropdown-end">
+            <summary className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-base-300 bg-base-100 text-[13px] font-medium text-base-content/70 hover:bg-base-200 cursor-pointer select-none">
+              <span>
+                Group by: <b className="text-base-content font-semibold">{groupByLabel}</b>
+              </span>
+              <ChevronDownIcon className="w-3 h-3 text-base-content/50" />
+            </summary>
+            <ul className="dropdown-content z-high mt-2 menu p-1 shadow-lg bg-base-100 rounded-box w-44 border border-base-300">
+              {METRICS_FACTOR_LABELS.map((optionLabel, index) => (
+                <li key={optionLabel}>
+                  <a
+                    className={factor === index ? "bg-primary/10 text-primary font-semibold" : ""}
+                    onClick={(e) => {
+                      onFactorChange(index);
+                      closeDropdown(e);
+                    }}
+                  >
+                    {optionLabel}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </details>
+          <div
+            className="flex items-center justify-center w-8 h-8 text-[11px] font-semibold text-base-content/60 bg-base-200 border border-base-300 rounded-lg"
+            title="Bucket size for the current range"
+          >
+            {getBucketLabel(range)}
+          </div>
+          <div
+            className="text-[11px] font-semibold text-base-content/60 bg-base-200 border border-base-300 rounded-lg px-2.5 py-1 whitespace-nowrap"
+            title="Average across the visible periods"
+          >
+            Avg {activeMetric.format(averageValue)}
+          </div>
+        </div>
+      </div>
+
+      {/* Always fills the card's actual width, at any data-point count - no
+          fixed min-width + horizontal scroll, which could force the chart
+          wider than its container and spill into neighboring UI. Bars shrink
+          to fit (capped by maxBarSize so they never look absurdly wide on
+          short ranges like "Last 1 Hour"). */}
+      <div style={{ width: "100%", height: "360px" }}>
         <ResponsiveContainer width="100%" height="100%">
-          <BarChart data={data} barCategoryGap="20%">
-            <CartesianGrid strokeDasharray="3 3" stroke={gridColor} />
+          <BarChart data={data} barCategoryGap="25%">
+            <CartesianGrid strokeDasharray="3 3" stroke={gridColor} vertical={false} />
             <XAxis
               dataKey="period"
               tick={{ fill: axisColor, fontSize: 11 }}
@@ -76,20 +310,94 @@ const MetricsChart = memo(({ rawData, currentTheme, factor }) => {
             <YAxis
               tick={{ fill: axisColor, fontSize: 11 }}
               axisLine={{ stroke: axisColor }}
-              tickLine={{ stroke: axisColor }}
-              tickFormatter={(value) => "$" + (value?.toFixed(2) || "0.00")}
-              label={{
-                value: "Cost ( in $ )",
-                angle: -90,
-                position: "insideLeft",
-                offset: 10,
-                style: { fill: axisColor, fontSize: 12 },
-              }}
+              tickLine={false}
+              tickFormatter={(value) => activeMetric.format(value)}
             />
             <Tooltip content={<CustomTooltip />} cursor={{ fill: "rgba(113, 117, 115, 0.15)" }} />
-            <Bar dataKey="totalCost" fill="#4ade80" radius={[4, 4, 0, 0]} />
+            {/* No attached label here on purpose - Recharts positions a
+                  ReferenceLine's label relative to the LINE's own y-value,
+                  not a fixed spot in the chart. When the average sits low
+                  (e.g. a quiet 24h window), that label would land right on
+                  top of the x-axis. The average is shown as a fixed badge in
+                  the header above instead, so it never collides with the
+                  chart regardless of the data. */}
+            <ReferenceLine y={averageValue} stroke={axisColor} strokeDasharray="4 4" strokeOpacity={0.6} />
+            {topEntities.map((entity, index) => {
+              const isTopmostSegment = !hasOther && index === topEntities.length - 1;
+              return (
+                <Bar
+                  key={entity.id}
+                  dataKey={entity.id}
+                  stackId="stack"
+                  fill={entity.color}
+                  radius={isTopmostSegment ? [4, 4, 0, 0] : [0, 0, 0, 0]}
+                  maxBarSize={48}
+                />
+              );
+            })}
+            {hasOther && (
+              <Bar dataKey={OTHER_KEY} stackId="stack" fill={OTHER_COLOR} radius={[4, 4, 0, 0]} maxBarSize={48} />
+            )}
           </BarChart>
         </ResponsiveContainer>
+      </div>
+
+      {/* Legend: one chip per top entity + Other, click to toggle out of the stack */}
+      <div className="flex flex-wrap gap-2 mt-4">
+        {topEntities.map((entity) => (
+          <button
+            key={entity.id}
+            type="button"
+            onClick={() => toggleLegend(entity.id)}
+            className={`flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-xs transition-opacity ${
+              hiddenIds.has(entity.id) ? "opacity-40 border-base-300" : "border-base-300"
+            }`}
+          >
+            <span className="w-2 h-2 rounded-sm flex-shrink-0" style={{ backgroundColor: entity.color }} />
+            <span className="truncate max-w-[140px]">{entity.name}</span>
+          </button>
+        ))}
+        {overflowEntities.length > 0 && (
+          <details className="dropdown group">
+            <summary
+              className={`flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-xs cursor-pointer select-none transition-opacity ${
+                hiddenIds.has(OTHER_KEY) ? "opacity-40 border-base-300" : "border-base-300"
+              }`}
+            >
+              <span className="w-2 h-2 rounded-sm flex-shrink-0" style={{ backgroundColor: OTHER_COLOR }} />
+              <span>Other ({overflowEntities.length})</span>
+              <ChevronDownIcon className="w-3 h-3 text-base-content/50 transition-transform group-open:rotate-180" />
+            </summary>
+            <div className="dropdown-content z-high mt-2 p-1 shadow-lg bg-base-100 rounded-box w-56 border border-base-300">
+              <ul className="menu flex flex-col flex-nowrap p-0 w-full max-h-64 overflow-y-auto overflow-x-hidden">
+                {overflowEntities.map((entity) => {
+                  const isHidden = hiddenOverflowIds.has(entity.id);
+                  return (
+                    <li key={entity.id} className="w-full">
+                      <a
+                        className={`flex items-center gap-2 w-full truncate py-1.5 transition-opacity ${
+                          isHidden ? "opacity-40" : ""
+                        }`}
+                        onClick={() => toggleOverflow(entity.id)}
+                      >
+                        <span className="w-2 h-2 rounded-sm flex-shrink-0" style={{ backgroundColor: OTHER_COLOR }} />
+                        <span className="truncate">{entity.name}</span>
+                      </a>
+                    </li>
+                  );
+                })}
+              </ul>
+              <div className="flex justify-end pt-1 mt-1 border-t border-base-300">
+                <a
+                  className="text-xs text-base-content/60 hover:text-base-content px-2 py-1 cursor-pointer"
+                  onClick={() => toggleLegend(OTHER_KEY)}
+                >
+                  {hiddenIds.has(OTHER_KEY) ? "Show all" : "Hide all"}
+                </a>
+              </div>
+            </div>
+          </details>
+        )}
       </div>
     </div>
   );

--- a/components/metrics/MetricsFilters.js
+++ b/components/metrics/MetricsFilters.js
@@ -1,212 +1,139 @@
-import { memo } from "react";
-import { Calendar } from "lucide-react";
-import { TIME_RANGE_OPTIONS } from "@/utils/enums";
-import { ChevronDownIcon } from "@/components/Icons";
-import SearchItems from "@/components/UI/SearchItems";
+import { memo, useMemo } from "react";
+import TimeRangeFilter from "@/components/metrics/TimeRangeFilter";
+import MultiSelectFilterDropdown from "@/components/metrics/MultiSelectFilterDropdown";
+import ExportMetricsButton from "@/components/metrics/ExportMetricsButton";
+import { RefreshIcon, LayoutGridIcon, BlocksIcon, SparklesIcon, KeyRoundIcon } from "@/components/Icons";
+import { getApiKeyStatusClass, getIconOfService } from "@/utils/utility";
 
+// Which agents use a given API key isn't a direct field on either object -
+// both only carry it indirectly via version ids (same join ConnectedAgentsModal
+// uses for the "connected agents" list on the API Keys settings page).
+const countConnectedAgents = (apikey, allBridges) => {
+  const versionIdSet = new Set(apikey.version_ids || []);
+  if (!versionIdSet.size) return 0;
+  return allBridges.reduce((count, bridge) => {
+    const usesThisKey = (bridge.versions || []).some((versionId) => versionIdSet.has(versionId));
+    return usesThisKey ? count + 1 : count;
+  }, 0);
+};
+
+// Flat pill toolbar - matches the demo's filterbar: one row of pill buttons
+// (icon + "Label: value" + chevron) instead of the old label-above/select-box
+// grid. Group By now lives in the chart card header instead of here.
 const MetricsFilters = memo(
   ({
-    factor,
     range,
-    bridge,
-    loading,
-    filterBridges,
-    setFilterBridges,
-    allBridges,
     customStartDate,
     customEndDate,
-    onFactorChange,
-    onTimeRangeChange,
+    selectedBridgeIds = [],
+    selectedApikeyIds = [],
+    selectedModels = [],
+    selectedServices = [],
+    allBridges = [],
+    apikeyData = [],
+    modelOptions = [],
+    services = [],
+    loading,
     onBridgeChange,
-    getDisplayRangeText,
+    onApikeyChange,
+    onModelChange,
+    onServiceChange,
+    onTimeRangeChange,
+    onCustomRangeApply,
+    onRefresh,
+    exportProps,
   }) => {
-    const FACTOR_OPTIONS = ["Agents", "API Keys", "Models"];
+    // Same provider icon the real Agents list page shows next to each agent's
+    // name (getIconOfService, keyed off the agent's configured `service` -
+    // openai/anthropic/google/etc.) - not a dedicated icon/avatar field.
+    const bridgeOptions = allBridges.map((item) => ({
+      id: item._id,
+      name: item.name,
+      iconNode: getIconOfService(item.service, 16, 16),
+    }));
+    // API keys shown by name + status only (never the masked key value), with
+    // how many agents actually use each one - not just a flat name list.
+    const apikeyOptions = useMemo(
+      () =>
+        apikeyData.map((item) => {
+          const agentCount = countConnectedAgents(item, allBridges);
+          return {
+            id: item._id,
+            name: item.name,
+            dotClass: item.status ? getApiKeyStatusClass(item.status, "dot") : null,
+            meta: `${item.status || "unknown"} - ${agentCount} agent${agentCount === 1 ? "" : "s"}`,
+          };
+        }),
+      [apikeyData, allBridges]
+    );
+    const modelOptionsList = modelOptions.map((item) => ({ id: item.id, name: item.name }));
+    const serviceOptions = services.map((item) => ({
+      id: item.value,
+      name: item.displayName || item.value,
+      iconNode: getIconOfService(item.value, 16, 16),
+    }));
 
     return (
-      <div className="bg-base-100 shadow-md rounded-lg p-6 mb-6">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          {/* Group By Dropdown */}
-          <div className="flex items-center gap-2">
-            <span className="font-medium">Group by:</span>
-            <details
-              id="metrics-filter-group-by-dropdown"
-              data-testid="metrics-filter-group-by"
-              className="dropdown dropdown-end"
-              tabIndex={0}
-              onBlur={(e) => {
-                if (!e.currentTarget.contains(e.relatedTarget)) {
-                  e.currentTarget.removeAttribute("open");
-                }
-              }}
-            >
-              <summary
-                id="metrics-filter-group-by-button"
-                data-testid="metrics-filter-group-by-button"
-                className="btn btn-sm m-1"
-              >
-                {FACTOR_OPTIONS[factor]}
-                <ChevronDownIcon className="w-3 h-3 ml-2" />
-              </summary>
-              <ul tabIndex="0" className="dropdown-content menu p-1 shadow bg-base-100 rounded-box w-52 z-high">
-                {FACTOR_OPTIONS.map((item, index) => (
-                  <li key={index}>
-                    <a
-                      id={`metrics-filter-group-by-option-${index}`}
-                      data-testid={`metrics-filter-group-by-option-${index}`}
-                      className={`${factor === index ? "active" : ""}`}
-                      onClick={(e) => {
-                        onFactorChange(index);
-                        const details = e.currentTarget.closest("details");
-                        if (details) details.removeAttribute("open");
-                      }}
-                    >
-                      {item}
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            </details>
-          </div>
+      <div
+        className="flex items-center gap-2 flex-wrap bg-base-100 border border-base-300 rounded-lg p-2 mb-6"
+        data-testid="metrics-filterbar"
+      >
+        <TimeRangeFilter
+          range={range}
+          customStartDate={customStartDate}
+          customEndDate={customEndDate}
+          onPresetChange={onTimeRangeChange}
+          onCustomRangeApply={onCustomRangeApply}
+        />
+        <MultiSelectFilterDropdown
+          id="metrics-filter-agent"
+          label="Agent"
+          icon={<LayoutGridIcon className="w-3.5 h-3.5" />}
+          options={bridgeOptions}
+          selectedIds={selectedBridgeIds}
+          onChange={onBridgeChange}
+          searchable
+        />
+        <MultiSelectFilterDropdown
+          id="metrics-filter-service"
+          label="Service"
+          icon={<BlocksIcon className="w-3.5 h-3.5" />}
+          options={serviceOptions}
+          selectedIds={selectedServices}
+          onChange={onServiceChange}
+          searchable
+        />
+        <MultiSelectFilterDropdown
+          id="metrics-filter-model"
+          label="Model"
+          icon={<SparklesIcon className="w-3.5 h-3.5" />}
+          options={modelOptionsList}
+          selectedIds={selectedModels}
+          onChange={onModelChange}
+          searchable
+        />
+        <MultiSelectFilterDropdown
+          id="metrics-filter-apikey"
+          label="API Key"
+          icon={<KeyRoundIcon className="w-3.5 h-3.5" />}
+          options={apikeyOptions}
+          selectedIds={selectedApikeyIds}
+          onChange={onApikeyChange}
+          searchable
+        />
 
-          {/* Agent Selection */}
-          <div className="flex items-center gap-2">
-            <span className="font-medium">Agent:</span>
-            <details
-              id="metrics-filter-agent-dropdown"
-              data-testid="metrics-filter-agent-select"
-              className="dropdown dropdown-end z-high"
-              ref={(node) => {
-                if (node) {
-                  const handleClickOutside = (event) => {
-                    const isClickInsideSearch = event.target.closest(".search-container");
-                    const isClickInsideItem = event.target.closest(".dropdown-item");
-                    if (!node.contains(event.target) && !isClickInsideSearch && !isClickInsideItem) {
-                      node.removeAttribute("open");
-                    }
-                  };
-                  document.addEventListener("mousedown", handleClickOutside);
-                  node._clickOutsideHandler = handleClickOutside;
-                }
-              }}
-            >
-              <summary
-                id="metrics-filter-agent-button"
-                data-testid="metrics-filter-agent-button"
-                className="btn btn-sm m-1"
-              >
-                {bridge?.["bridge_name"]
-                  ? bridge?.["bridge_name"].length > 15
-                    ? bridge?.["bridge_name"].substring(0, 15) + "..."
-                    : bridge?.["bridge_name"]
-                  : "All Agents"}
-                <ChevronDownIcon className="w-3 h-3 ml-2" />
-              </summary>
+        <div className="flex-1" />
 
-              <ul className="menu dropdown-content bg-base-100 rounded-box z-high w-52 p-2 shadow-sm flex-row overflow-y-auto overflow-x-hidden min-w-72 max-w-72 scrollbar-hide max-h-[70vh]">
-                <div className="search-container">
-                  <SearchItems setFilterItems={setFilterBridges} data={allBridges} item="metrics" />
-                </div>
-
-                <li>
-                  <a
-                    id="metrics-filter-agent-all"
-                    data-testid="metrics-filter-agent-all"
-                    onClick={(e) => {
-                      onBridgeChange(null, null);
-                      const details = e.currentTarget.closest("details");
-                      if (details) details.removeAttribute("open");
-                    }}
-                    className={`w-72 mb-1 dropdown-item ${!bridge ? "active" : ""}`}
-                  >
-                    All Agents
-                  </a>
-                </li>
-
-                {filterBridges.map((item, index) => (
-                  <li key={index}>
-                    <a
-                      id={`metrics-filter-agent-${item?._id}`}
-                      data-testid={`metrics-filter-agent-option-${item?._id}`}
-                      onClick={(e) => {
-                        onBridgeChange(item?._id, item?.name);
-                        const details = e.currentTarget.closest("details");
-                        if (details) details.removeAttribute("open");
-                      }}
-                      className={`w-72 mb-1 dropdown-item ${bridge?.["bridge_id"] === item?._id ? "active" : ""}`}
-                    >
-                      {item.name}
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            </details>
-          </div>
-
-          {/* Time Range */}
-          <div className="flex items-center gap-2">
-            <span className="font-medium">Time Range:</span>
-            <details
-              id="metrics-filter-time-range-dropdown"
-              data-testid="metrics-filter-time-range"
-              className="dropdown dropdown-end"
-              tabIndex={0}
-              onBlur={(e) => {
-                if (!e.currentTarget.contains(e.relatedTarget)) {
-                  e.currentTarget.removeAttribute("open");
-                }
-              }}
-            >
-              <summary
-                id="metrics-filter-time-range-button"
-                data-testid="metrics-filter-time-range-button"
-                className="btn btn-sm m-1"
-              >
-                {range === 10 ? getDisplayRangeText() : TIME_RANGE_OPTIONS?.[range]}
-                <ChevronDownIcon className="w-3 h-3 ml-2" />
-              </summary>
-              <ul tabIndex="0" className="z-high dropdown-content menu p-1 shadow bg-base-100 rounded-box w-52">
-                {TIME_RANGE_OPTIONS.map((item, index) => (
-                  <li key={index}>
-                    <a
-                      id={`metrics-filter-time-range-option-${index}`}
-                      data-testid={`metrics-filter-time-range-option-${index}`}
-                      className={`${index === range && range !== 10 ? "active" : ""}`}
-                      onClick={(e) => {
-                        onTimeRangeChange(index);
-                        const details = e.currentTarget.closest("details");
-                        if (details) details.removeAttribute("open");
-                      }}
-                    >
-                      {item}
-                    </a>
-                  </li>
-                ))}
-                {/* Custom Range Option */}
-                <li>
-                  <a
-                    id="metrics-filter-time-range-custom"
-                    data-testid="metrics-filter-custom-range"
-                    className={`${range === 10 ? "active" : ""} flex items-center gap-2`}
-                    onClick={(e) => {
-                      onTimeRangeChange(TIME_RANGE_OPTIONS.length);
-                      const details = e.currentTarget.closest("details");
-                      if (details) details.removeAttribute("open");
-                    }}
-                  >
-                    <Calendar className="w-4 h-4" />
-                    Custom Range
-                  </a>
-                </li>
-              </ul>
-            </details>
-          </div>
-
-          {/* Loading indicator */}
-          <div className="flex items-center">
-            <span className={`${loading ? "loading loading-ring loading-md" : ""}`}></span>
-            {loading && <span className="text-gray-600 ml-2">Loading...</span>}
-          </div>
-        </div>
+        <button
+          type="button"
+          title="Refresh"
+          onClick={onRefresh}
+          disabled={loading}
+          className="w-9 h-9 rounded-lg border border-base-300 bg-base-100 flex items-center justify-center text-base-content/70 hover:bg-base-200 hover:text-base-content transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <RefreshIcon className={`w-4 h-4 ${loading ? "animate-spin" : ""}`} />
+        </button>
+        {exportProps && <ExportMetricsButton {...exportProps} />}
       </div>
     );
   }

--- a/components/metrics/MultiSelectFilterDropdown.js
+++ b/components/metrics/MultiSelectFilterDropdown.js
@@ -1,0 +1,145 @@
+import { memo, useMemo, useState } from "react";
+import { ChevronDownIcon, CheckIcon } from "@/components/Icons";
+
+// Multi-select variant of the metrics FilterDropdown: checkboxes instead of a
+// single active row, plus a search box. selectedIds=[] means "no filter -
+// everything included" server-side, but is rendered with every box UNCHECKED
+// (not all ticked) - showing them all as checked would mean picking a second
+// or third item requires first unchecking every other one, which is
+// backwards from how a fresh multi-select is normally used.
+const MultiSelectFilterDropdown = memo(
+  ({ id, label, icon, options = [], selectedIds = [], onChange, searchable = false }) => {
+    const [searchTerm, setSearchTerm] = useState("");
+
+    const filteredOptions = useMemo(() => {
+      const query = searchTerm.trim().toLowerCase();
+      if (!query) return options;
+      return options.filter((option) =>
+        String(option?.name || "")
+          .toLowerCase()
+          .includes(query)
+      );
+    }, [options, searchTerm]);
+
+    const isAllState = selectedIds.length === 0;
+    const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds]);
+
+    const toggleOption = (optionId) => {
+      if (isAllState) {
+        // Coming from "everything selected", clicking one item narrows down
+        // to just that item - not "everyone except this one" (which used to
+        // build a filter list of every other id, sometimes hundreds of them,
+        // for what the user meant as a single-item filter).
+        onChange([optionId]);
+        return;
+      }
+      const next = selectedSet.has(optionId)
+        ? selectedIds.filter((optId) => optId !== optionId)
+        : [...selectedIds, optionId];
+      // If toggling back on lands on literally every option, collapse to the
+      // implicit all-state so the trigger label stays clean.
+      onChange(next.length === options.length ? [] : next);
+    };
+
+    const triggerLabel = isAllState
+      ? label
+      : selectedIds.length === 1
+        ? `${label}: ${options.find((option) => option.id === selectedIds[0])?.name || "1 selected"}`
+        : `${label}: ${selectedIds.length} selected`;
+    const isActive = !isAllState;
+
+    return (
+      <details
+        id={id}
+        data-testid={`metrics-filter-${label.toLowerCase().replace(/ /g, "-")}`}
+        className="dropdown"
+        tabIndex={0}
+        onBlur={(e) => {
+          if (!e.currentTarget.contains(e.relatedTarget)) {
+            e.currentTarget.removeAttribute("open");
+          }
+        }}
+      >
+        <summary
+          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg border text-[13px] font-medium cursor-pointer select-none transition-colors ${
+            isActive
+              ? "bg-primary/10 border-primary text-base-content"
+              : "bg-base-100 border-base-300 text-base-content/70 hover:bg-base-200"
+          }`}
+        >
+          {icon}
+          <span className="truncate max-w-[160px]">{triggerLabel}</span>
+          <ChevronDownIcon className="w-3 h-3 flex-shrink-0 text-base-content/50" />
+        </summary>
+
+        {/* Centered under its own trigger (left-1/2 + -translate-x-1/2) instead
+            of a hardcoded left/right side - a fixed side only stays correct
+            for as long as this pill sits at that same spot in the toolbar.
+            Centering keeps it anchored to its own button regardless of where
+            the row wraps or reflows, so it can't drift off past the left or
+            right edge of the screen depending on which filter it is. */}
+        <div className="dropdown-content z-high mt-2 left-1/2 -translate-x-1/2 p-1 shadow-lg bg-base-100 rounded-box w-64 max-w-[90vw] border border-base-300">
+          {searchable && (
+            <div className="px-1 pb-1">
+              <input
+                autoComplete="off"
+                type="text"
+                placeholder="Search..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="input input-sm w-full bg-base-200 border-base-content/20"
+              />
+            </div>
+          )}
+          <ul className="menu flex flex-col flex-nowrap p-0 max-h-64 w-full overflow-y-auto overflow-x-hidden">
+            {filteredOptions.map((option) => {
+              const checked = selectedSet.has(option.id);
+              return (
+                <li key={option.id} className="w-full">
+                  <a className="flex items-center gap-2 w-full truncate py-2" onClick={() => toggleOption(option.id)}>
+                    <span
+                      className={`w-4 h-4 rounded flex items-center justify-center border flex-shrink-0 ${
+                        checked ? "bg-primary border-primary" : "border-base-content/30"
+                      }`}
+                    >
+                      {checked && <CheckIcon className="w-3 h-3 text-primary-content" />}
+                    </span>
+                    {option.dotClass && (
+                      <span className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${option.dotClass}`} />
+                    )}
+                    {option.iconNode && <span className="flex items-center flex-shrink-0">{option.iconNode}</span>}
+                    <span className="flex flex-col min-w-0 flex-1">
+                      <span className="truncate">{option.name}</span>
+                      {option.meta && (
+                        <span className="text-[10.5px] text-base-content/50 truncate">{option.meta}</span>
+                      )}
+                    </span>
+                  </a>
+                </li>
+              );
+            })}
+            {filteredOptions.length === 0 && (
+              <li>
+                <a className="pointer-events-none text-base-content/50">No options found</a>
+              </li>
+            )}
+          </ul>
+          {!isAllState && (
+            <div className="flex justify-end pt-1 mt-1 border-t border-base-300">
+              <a
+                className="text-xs text-base-content/60 hover:text-base-content px-2 py-1 cursor-pointer"
+                onClick={() => onChange([])}
+              >
+                Reset ({selectedIds.length})
+              </a>
+            </div>
+          )}
+        </div>
+      </details>
+    );
+  }
+);
+
+MultiSelectFilterDropdown.displayName = "MultiSelectFilterDropdown";
+
+export default MultiSelectFilterDropdown;

--- a/components/metrics/RequestActivityCard.js
+++ b/components/metrics/RequestActivityCard.js
@@ -1,0 +1,128 @@
+import { memo, useState } from "react";
+import { LineChart, Line, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
+import { ChartIcon, LineChartIcon } from "@/components/Icons";
+
+const SUCCESS_COLOR = "#4ade80";
+const FAILED_COLOR = "#f87171";
+
+// Real success vs failed request counts over time, from conversation_logs
+// (via POST /api/metrics/requests-activity) - not simulated. Only real when
+// `data` is non-empty; a genuinely idle window (0 requests) renders as a
+// flat empty-state chart, same as any other card.
+const RequestActivityCard = memo(({ data = [] }) => {
+  const [chartType, setChartType] = useState("line");
+
+  const chartData = data.map((row) => ({
+    t: new Date(row.t).toLocaleString("en-US", { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" }),
+    success: Number(row.success) || 0,
+    failed: Number(row.failed) || 0,
+    avgLatency: row.avg_latency != null ? Number(row.avg_latency) : null,
+  }));
+
+  const totalSuccess = chartData.reduce((sum, row) => sum + row.success, 0);
+  const totalFailed = chartData.reduce((sum, row) => sum + row.failed, 0);
+  const totalRequests = totalSuccess + totalFailed;
+  const errorRate = totalRequests > 0 ? ((totalFailed / totalRequests) * 100).toFixed(1) : "0.0";
+
+  // Weighted by each bucket's successful-request count, not a plain mean of
+  // per-bucket averages (which would let a near-empty bucket skew the result
+  // as much as a busy one).
+  const latencyWeightedSum = chartData.reduce(
+    (sum, row) => sum + (row.avgLatency != null ? row.avgLatency * row.success : 0),
+    0
+  );
+  const latencyWeight = chartData.reduce((sum, row) => sum + (row.avgLatency != null ? row.success : 0), 0);
+  const avgLatency = latencyWeight > 0 ? Math.round(latencyWeightedSum / latencyWeight) : null;
+
+  const ChartComponent = chartType === "bar" ? BarChart : LineChart;
+  const SeriesComponent = chartType === "bar" ? Bar : Line;
+  const seriesProps = chartType === "bar" ? { radius: [2, 2, 0, 0] } : { type: "monotone", strokeWidth: 2, dot: false };
+
+  return (
+    <div className="bg-base-100 shadow-md rounded-lg p-4 h-full flex flex-col" data-testid="request-activity-card">
+      <div className="flex items-start justify-between gap-2">
+        <h2 className="text-sm font-bold text-base-content">Request Activity</h2>
+        <button
+          type="button"
+          title={chartType === "line" ? "Switch to bar chart" : "Switch to line chart"}
+          onClick={() => setChartType((t) => (t === "line" ? "bar" : "line"))}
+          className="w-7 h-7 rounded-lg border border-base-300 bg-base-100 flex items-center justify-center text-base-content/60 hover:bg-base-200 hover:text-base-content flex-shrink-0 transition-colors"
+        >
+          {chartType === "line" ? <ChartIcon className="w-3.5 h-3.5" /> : <LineChartIcon className="w-3.5 h-3.5" />}
+        </button>
+      </div>
+      <div className="text-[11px] font-semibold tracking-wide text-base-content/50 uppercase mt-0.5">
+        Total Requests: <span className="text-base-content">{totalRequests.toLocaleString()}</span>
+      </div>
+
+      <div className="flex flex-wrap gap-x-5 gap-y-2 mt-3">
+        <div>
+          <div className="text-lg font-bold text-success leading-none">{totalSuccess.toLocaleString()}</div>
+          <div className="flex items-center gap-1.5 text-[11px] text-base-content/50 mt-1">
+            <span className="w-1.5 h-1.5 rounded-sm bg-success flex-shrink-0" />
+            Successful
+          </div>
+        </div>
+        <div>
+          <div className="text-lg font-bold text-error leading-none">{totalFailed.toLocaleString()}</div>
+          <div className="flex items-center gap-1.5 text-[11px] text-base-content/50 mt-1">
+            <span className="w-1.5 h-1.5 rounded-sm bg-error flex-shrink-0" />
+            Failed
+          </div>
+        </div>
+        <div>
+          <div className="text-lg font-bold text-base-content leading-none">{errorRate}%</div>
+          <div className="text-[11px] text-base-content/50 mt-1">Error rate</div>
+        </div>
+        <div>
+          <div className="text-lg font-bold text-base-content leading-none">
+            {avgLatency !== null ? `${avgLatency} ms` : "-"}
+          </div>
+          <div className="text-[11px] text-base-content/50 mt-1">Avg latency</div>
+        </div>
+      </div>
+
+      {chartData.length === 0 ? (
+        <div className="flex-1 min-h-[200px] flex items-center justify-center text-base-content/60 text-sm">
+          No requests in this period
+        </div>
+      ) : (
+        <div className="flex-1 min-h-[200px] mt-3 -ml-2">
+          <ResponsiveContainer width="100%" height="100%">
+            <ChartComponent data={chartData}>
+              <CartesianGrid strokeDasharray="3 3" className="stroke-base-300" vertical={false} />
+              <XAxis dataKey="t" tick={{ fontSize: 10 }} className="fill-base-content/70" minTickGap={24} />
+              <YAxis tick={{ fontSize: 10 }} className="fill-base-content/70" allowDecimals={false} width={30} />
+              <Tooltip
+                contentStyle={{
+                  background: "var(--fallback-b1,oklch(var(--b1)))",
+                  border: "1px solid var(--fallback-b3,oklch(var(--b3)))",
+                  borderRadius: "0.5rem",
+                  fontSize: "12px",
+                }}
+              />
+              <SeriesComponent
+                dataKey="success"
+                name="Successful"
+                fill={SUCCESS_COLOR}
+                stroke={SUCCESS_COLOR}
+                {...seriesProps}
+              />
+              <SeriesComponent
+                dataKey="failed"
+                name="Failed"
+                fill={FAILED_COLOR}
+                stroke={FAILED_COLOR}
+                {...seriesProps}
+              />
+            </ChartComponent>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </div>
+  );
+});
+
+RequestActivityCard.displayName = "RequestActivityCard";
+
+export default RequestActivityCard;

--- a/components/metrics/TimeRangeFilter.js
+++ b/components/metrics/TimeRangeFilter.js
@@ -1,0 +1,219 @@
+import { memo, useState, useMemo } from "react";
+import { METRICS_TIME_RANGE_OPTIONS } from "@/utils/enums";
+import { ChevronDownIcon, ChevronLeftIcon, ChevronRightIcon, CalendarIcon } from "@/components/Icons";
+
+const CUSTOM_RANGE = 10;
+const DOW = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+
+const closeDropdown = (event) => {
+  event.currentTarget.closest("details")?.removeAttribute("open");
+};
+
+const isSameDay = (a, b) =>
+  a && b && a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+
+const buildMonthCells = (monthDate) => {
+  const year = monthDate.getFullYear();
+  const month = monthDate.getMonth();
+  const firstDow = new Date(year, month, 1).getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const cells = [];
+  for (let i = 0; i < firstDow; i++) cells.push(null);
+  for (let d = 1; d <= daysInMonth; d++) cells.push(new Date(year, month, d));
+  return cells;
+};
+
+const formatCustomLabel = (start, end) => {
+  if (!start || !end) return "Custom Range";
+  const startStr = start.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  const endStr = end.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+  return `${startStr} - ${endStr}`;
+};
+
+const MonthGrid = memo(({ monthDate, pickStart, pickEnd, onPickDay, onNav, showPrevNav, showNextNav }) => {
+  const cells = useMemo(() => buildMonthCells(monthDate), [monthDate]);
+  const today = new Date();
+  const label = monthDate.toLocaleDateString("en-US", { month: "long", year: "numeric" });
+
+  return (
+    <div className="flex-1">
+      <div className="flex items-center justify-between mb-2">
+        <button
+          type="button"
+          onClick={() => onNav(-1)}
+          className={`btn btn-ghost btn-xs btn-circle ${showPrevNav ? "" : "invisible"}`}
+        >
+          <ChevronLeftIcon className="w-3.5 h-3.5" />
+        </button>
+        <span className="text-sm font-semibold">{label}</span>
+        <button
+          type="button"
+          onClick={() => onNav(1)}
+          className={`btn btn-ghost btn-xs btn-circle ${showNextNav ? "" : "invisible"}`}
+        >
+          <ChevronRightIcon className="w-3.5 h-3.5" />
+        </button>
+      </div>
+      <div className="grid grid-cols-7 gap-0.5">
+        {DOW.map((d) => (
+          <div key={d} className="text-[10px] text-center text-base-content/50 font-semibold py-1">
+            {d}
+          </div>
+        ))}
+        {cells.map((date, i) => {
+          if (!date) return <div key={`pad-${i}`} className="aspect-square" />;
+          const inRange = pickStart && pickEnd && date > pickStart && date < pickEnd;
+          const isStart = isSameDay(date, pickStart);
+          const isEnd = isSameDay(date, pickEnd);
+          const isToday = isSameDay(date, today);
+          const isFuture = date > today;
+          return (
+            <button
+              type="button"
+              key={date.toISOString()}
+              disabled={isFuture}
+              onClick={() => onPickDay(date)}
+              className={[
+                "aspect-square rounded-md text-xs flex items-center justify-center",
+                isFuture ? "text-base-content/20 cursor-not-allowed" : "hover:bg-base-300 cursor-pointer",
+                inRange ? "bg-primary/10" : "",
+                isStart || isEnd ? "bg-primary text-primary-content font-semibold" : "",
+                isToday && !isStart && !isEnd ? "ring-1 ring-primary" : "",
+              ].join(" ")}
+            >
+              {date.getDate()}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+});
+MonthGrid.displayName = "MonthGrid";
+
+// Time Range filter: same trigger styling as the other FilterDropdowns, but
+// its popup combines the preset list with a two-month calendar grid (for the
+// custom range option, the existing "custom start/end date" mode that
+// useMetricsData already supports but no UI control previously reached).
+const TimeRangeFilter = memo(({ range, customStartDate, customEndDate, onPresetChange, onCustomRangeApply }) => {
+  const [calMonth0, setCalMonth0] = useState(() => {
+    const base = customStartDate ? new Date(customStartDate) : new Date();
+    return new Date(base.getFullYear(), base.getMonth() - 1, 1);
+  });
+  const [pickStart, setPickStart] = useState(customStartDate ? new Date(customStartDate) : null);
+  const [pickEnd, setPickEnd] = useState(customEndDate ? new Date(customEndDate) : null);
+
+  const isCustom = range === CUSTOM_RANGE;
+  const selectedPreset = METRICS_TIME_RANGE_OPTIONS.find((opt) => opt.range === range);
+  const label = isCustom ? formatCustomLabel(customStartDate, customEndDate) : selectedPreset?.label || "Select Range";
+
+  const handleNav = (dir) => setCalMonth0((prev) => new Date(prev.getFullYear(), prev.getMonth() + dir, 1));
+
+  const handlePickDay = (date) => {
+    if (!pickStart || (pickStart && pickEnd)) {
+      setPickStart(date);
+      setPickEnd(null);
+    } else if (date < pickStart) {
+      setPickStart(date);
+    } else {
+      setPickEnd(date);
+    }
+  };
+
+  const handleApply = (event) => {
+    if (pickStart && pickEnd) {
+      onCustomRangeApply(pickStart, pickEnd);
+      closeDropdown(event);
+    }
+  };
+
+  const rightMonth = new Date(calMonth0.getFullYear(), calMonth0.getMonth() + 1, 1);
+
+  return (
+    <details
+      data-testid="metrics-filter-time-range"
+      className="dropdown"
+      tabIndex={0}
+      onBlur={(e) => {
+        if (!e.currentTarget.contains(e.relatedTarget)) {
+          e.currentTarget.removeAttribute("open");
+        }
+      }}
+    >
+      <summary className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-primary bg-primary/10 text-[13px] font-medium text-base-content cursor-pointer select-none">
+        <CalendarIcon className="w-3.5 h-3.5 flex-shrink-0" />
+        <span className="truncate max-w-[180px]">{label}</span>
+        <ChevronDownIcon className="w-3 h-3 flex-shrink-0 text-base-content/50" />
+      </summary>
+
+      <div className="dropdown-content z-high mt-2 shadow-lg bg-base-100 rounded-box border border-base-300 flex">
+        <ul className="menu p-2 w-40 flex-shrink-0 border-r border-base-300">
+          {METRICS_TIME_RANGE_OPTIONS.map((opt) => (
+            <li key={opt.range}>
+              <a
+                className={`block truncate ${
+                  (!isCustom && range === opt.range) || (isCustom && opt.range === CUSTOM_RANGE)
+                    ? "bg-primary/10 text-primary font-semibold"
+                    : ""
+                }`}
+                onClick={(e) => {
+                  if (opt.range === CUSTOM_RANGE) return; // applied via the calendar's own Apply button instead
+                  onPresetChange(opt.range);
+                  closeDropdown(e);
+                }}
+              >
+                {opt.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+        <div className="p-3 w-[380px]">
+          <div className="flex gap-4">
+            <MonthGrid
+              monthDate={calMonth0}
+              pickStart={pickStart}
+              pickEnd={pickEnd}
+              onPickDay={handlePickDay}
+              onNav={handleNav}
+              showPrevNav
+              showNextNav={false}
+            />
+            <MonthGrid
+              monthDate={rightMonth}
+              pickStart={pickStart}
+              pickEnd={pickEnd}
+              onPickDay={handlePickDay}
+              onNav={handleNav}
+              showPrevNav={false}
+              showNextNav
+            />
+          </div>
+          <div className="flex items-center justify-between mt-3 pt-3 border-t border-base-300">
+            <span className="text-xs text-base-content/60 font-mono">
+              {pickStart && pickEnd
+                ? `${pickStart.toLocaleDateString("en-US", { month: "short", day: "numeric" })} - ${pickEnd.toLocaleDateString(
+                    "en-US",
+                    { month: "short", day: "numeric", year: "numeric" }
+                  )}`
+                : pickStart
+                  ? `${pickStart.toLocaleDateString("en-US", { month: "short", day: "numeric" })} - select end date`
+                  : "Select a start and end date"}
+            </span>
+            <button
+              type="button"
+              className="btn btn-primary btn-sm"
+              disabled={!pickStart || !pickEnd}
+              onClick={handleApply}
+            >
+              Apply
+            </button>
+          </div>
+        </div>
+      </div>
+    </details>
+  );
+});
+
+TimeRangeFilter.displayName = "TimeRangeFilter";
+
+export default TimeRangeFilter;

--- a/components/metrics/TokenUsageOverview.js
+++ b/components/metrics/TokenUsageOverview.js
@@ -1,48 +1,221 @@
-import { memo } from "react";
+import { memo, useMemo, useState } from "react";
 import { aggregateDataByFactor } from "@/customHooks/useMetricsData";
+import { METRICS_FACTOR_OPTIONS } from "@/utils/enums";
+import { MoveDownIcon, ChevronDownIcon } from "@/components/Icons";
+import { colorForId, formatTokensFull, formatCost } from "./metricsUtils";
+import { getIconOfService } from "@/utils/utility";
 
-const TokenUsageOverview = memo(({ rawData }) => {
-  const aggregatedData = aggregateDataByFactor(rawData);
+const BASE_HEADERS = [
+  { key: "name", label: "Agent (Models)", align: "left" },
+  { key: "successCount", label: "Requests", align: "right" },
+  { key: "tokens", label: "Tokens", align: "right" },
+  { key: "avgLatency", label: "Avg Latency", align: "right" },
+  { key: "cost", label: "Cost", align: "right" },
+];
+// Only shown when grouped by Agent - real input/output token totals per
+// agent, from conversation_logs (see agentTokenBreakdown prop). Not sortable
+// on their own key since they're a separate data source joined in by id,
+// not a field on the aggregated row itself.
+const TOKEN_SPLIT_HEADERS = [
+  { key: "inputTokens", label: "Input", align: "right", sortable: false },
+  { key: "outputTokens", label: "Output", align: "right", sortable: false },
+];
+const BASE_GRID_COLS = "1.9fr 0.9fr 0.9fr 0.9fr 0.9fr";
+const AGENT_GRID_COLS = `${BASE_GRID_COLS} 0.8fr 0.8fr`;
+
+// "(model)" for a single model, "(model +N)" for several - matches how the
+// reference design tags each agent row with its model usage at a glance,
+// without needing to expand.
+const modelTag = (breakdown) => {
+  if (!breakdown || breakdown.length === 0) return null;
+  if (breakdown.length === 1) return breakdown[0].name;
+  return `${breakdown[0].name} +${breakdown.length - 1}`;
+};
+
+// Models panel: an accordion list. Clicking an agent row expands its
+// per-model breakdown instantly - no fetch needed, since the backend now
+// carries a `model` column on every row when grouped by Agent, so the whole
+// breakdown is already sitting in `agentModelBreakdown` from the same
+// request that populated the table itself.
+const TokenUsageOverview = memo(({ rawData, factor, agentModelBreakdown = {}, agentTokenBreakdown = {} }) => {
+  const [sortKey, setSortKey] = useState("tokens");
+  const [sortDir, setSortDir] = useState("desc");
+  const [expandedId, setExpandedId] = useState(null);
+
+  const isAgentGrouping = METRICS_FACTOR_OPTIONS[factor] === "bridge_id";
+  const HEADERS = isAgentGrouping ? [...BASE_HEADERS, ...TOKEN_SPLIT_HEADERS] : BASE_HEADERS;
+  const gridCols = isAgentGrouping ? AGENT_GRID_COLS : BASE_GRID_COLS;
+  const aggregatedData = useMemo(() => aggregateDataByFactor(rawData), [rawData]);
+  const maxTokens = aggregatedData.length > 0 ? Math.max(...aggregatedData.map((item) => item.tokens)) : 0;
+
+  const sortedData = useMemo(() => {
+    const sorted = [...aggregatedData];
+    sorted.sort((a, b) => {
+      if (sortKey === "name") {
+        const result = String(a.name || "").localeCompare(String(b.name || ""));
+        return sortDir === "asc" ? result : -result;
+      }
+      const valueA = Number(a[sortKey]) || 0;
+      const valueB = Number(b[sortKey]) || 0;
+      return sortDir === "asc" ? valueA - valueB : valueB - valueA;
+    });
+    return sorted;
+  }, [aggregatedData, sortKey, sortDir]);
+
+  const handleSort = (key, sortable = true) => {
+    if (!sortable) return;
+    if (sortKey === key) {
+      setSortDir((dir) => (dir === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir(key === "name" ? "asc" : "desc");
+    }
+  };
+
+  const handleRowClick = (agentId) => {
+    if (!isAgentGrouping) return;
+    setExpandedId((prev) => (prev === agentId ? null : agentId));
+  };
 
   if (aggregatedData.length === 0) {
     return (
-      <div className="bg-base-100 shadow-md rounded-lg p-6">
-        <h2 className="text-lg font-bold mb-4">Token Usage Overview</h2>
-        <div className="text-center py-4">
-          <div className="text-base-content opacity-60">No data available</div>
+      <div className="bg-base-100 shadow-md rounded-lg overflow-hidden">
+        <div className="px-5 py-4 border-b border-base-300">
+          <h2 className="text-[14.5px] font-bold text-base-content">Models</h2>
         </div>
+        <div className="text-center py-8 text-base-content/60">No data available</div>
       </div>
     );
   }
 
-  const maxTokens = Math.max(...aggregatedData.map((i) => i.tokens));
-
   return (
-    <div className="bg-base-100 shadow-md rounded-lg p-6">
-      <h2 className="text-lg font-bold mb-4">Token Usage Overview</h2>
-      <div className="space-y-3 max-h-96 overflow-y-auto">
-        {aggregatedData.map((item, index) => {
-          const widthPercentage = maxTokens > 0 ? (item.tokens / maxTokens) * 95 : 0;
+    <div className="bg-base-100 shadow-md rounded-lg overflow-hidden" data-testid="token-usage-overview">
+      <div className="px-5 py-4 border-b border-base-300">
+        <h2 className="text-[14.5px] font-bold text-base-content">Models</h2>
+      </div>
 
-          return (
-            <div key={index} className="relative mb-2">
-              <div
-                className="absolute inset-0 bg-base-300 rounded transition-all duration-300"
-                style={{ width: `${widthPercentage}%` }}
-              ></div>
+      <div className="overflow-x-auto">
+        <div className={isAgentGrouping ? "min-w-[900px]" : "min-w-[720px]"}>
+          <div
+            className="grid gap-2 px-5 py-2.5 border-b border-base-300 text-[11px] uppercase tracking-wide font-bold text-base-content/50"
+            style={{ gridTemplateColumns: gridCols }}
+          >
+            {HEADERS.map((header) => {
+              const sortable = header.sortable !== false;
+              const isActive = sortable && sortKey === header.key;
+              return (
+                <div
+                  key={header.key}
+                  onClick={() => handleSort(header.key, sortable)}
+                  className={`flex items-center gap-1 select-none ${sortable ? "cursor-pointer" : ""} ${
+                    header.align === "right" ? "justify-end" : ""
+                  }`}
+                >
+                  <span>{header.label}</span>
+                  {sortable && (
+                    <MoveDownIcon
+                      className={`w-3 h-3 transition-colors ${isActive ? "text-base-content" : "text-base-content/25"} ${
+                        isActive && sortDir === "asc" ? "rotate-180" : "rotate-0"
+                      }`}
+                    />
+                  )}
+                </div>
+              );
+            })}
+          </div>
 
-              <div className="relative flex items-center justify-between p-2 z-10">
-                <div className="flex-grow overflow-hidden text-ellipsis">
-                  <div className="text-base-content font-medium text-sm">{item.name || `Item ${index + 1}`}</div>
+          {sortedData.map((item) => {
+            const color = colorForId(item.id);
+            const percentage = maxTokens > 0 ? Math.round((item.tokens / maxTokens) * 100) : 0;
+            const isExpanded = expandedId === item.id;
+            const breakdown = agentModelBreakdown[item.id];
+            const tag = isAgentGrouping ? modelTag(breakdown) : null;
+            const tokenSplit = isAgentGrouping ? agentTokenBreakdown[item.id] : null;
+
+            return (
+              <div key={item.id} className="border-b border-base-300 last:border-b-0">
+                <div
+                  onClick={() => handleRowClick(item.id)}
+                  className={`grid gap-2 items-center px-5 py-3 ${
+                    isAgentGrouping ? "cursor-pointer hover:bg-base-200/60" : ""
+                  }`}
+                  style={{ gridTemplateColumns: gridCols }}
+                >
+                  <div className="flex items-center gap-1.5 min-w-0">
+                    <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: color }} />
+                    {/* Same provider icon (openai/anthropic/...) the real Agents
+                        list page shows next to each agent's name - only
+                        meaningful for Agent/Service groupings, where the row
+                        maps to exactly one service. */}
+                    {item.service && (
+                      <span className="flex items-center flex-shrink-0">{getIconOfService(item.service, 16, 16)}</span>
+                    )}
+                    <span className="font-semibold text-[13.5px] text-base-content truncate" title={item.name}>
+                      {item.name}
+                    </span>
+                    {tag && <span className="text-[12px] text-base-content/50 truncate">({tag})</span>}
+                    {isAgentGrouping && breakdown?.length > 0 && (
+                      <ChevronDownIcon
+                        className={`w-3.5 h-3.5 text-base-content/50 flex-shrink-0 transition-transform ${
+                          isExpanded ? "rotate-180" : ""
+                        }`}
+                      />
+                    )}
+                  </div>
+                  <div className="text-right text-[12.5px] text-base-content/70">
+                    {formatTokensFull(item.successCount)}
+                  </div>
+                  <div className="relative text-right text-[12.5px] font-medium text-base-content rounded overflow-hidden px-1.5 py-0.5 -mx-1.5">
+                    <span
+                      className="absolute inset-y-0 left-0 bg-primary/10 rounded"
+                      style={{ width: `${percentage}%` }}
+                    />
+                    <span className="relative">{formatTokensFull(item.tokens)}</span>
+                  </div>
+                  <div className="text-right text-[12.5px] text-base-content/70">
+                    {item.avgLatency > 0 ? `${Math.round(item.avgLatency)} ms` : "-"}
+                  </div>
+                  <div className="text-right text-[12.5px] text-base-content/70">{formatCost(item.cost)}</div>
+                  {isAgentGrouping && (
+                    <>
+                      <div className="text-right text-[12.5px] text-primary">
+                        {tokenSplit ? formatTokensFull(tokenSplit.inputTokens) : "-"}
+                      </div>
+                      <div className="text-right text-[12.5px] text-secondary">
+                        {tokenSplit ? formatTokensFull(tokenSplit.outputTokens) : "-"}
+                      </div>
+                    </>
+                  )}
                 </div>
-                <div className="ml-3 text-right flex-shrink-0">
-                  <div className="font-bold text-xs text-base-content">tokens: {item.tokens.toLocaleString()}</div>
-                  <div className="text-xs text-base-content opacity-60">cost: ${item.cost.toFixed(3)}</div>
-                </div>
+
+                {isAgentGrouping && isExpanded && breakdown?.length > 0 && (
+                  <div className="bg-base-200/40 px-5 pb-3">
+                    {breakdown.map((model) => (
+                      <div
+                        key={model.id}
+                        className="grid gap-2 items-center py-1.5 pl-6"
+                        style={{ gridTemplateColumns: gridCols }}
+                      >
+                        <div className="flex items-center gap-2 text-[12.5px] text-base-content/70 truncate">
+                          <span className="w-1 h-1 rounded-full bg-base-content/40 flex-shrink-0" />
+                          {model.name}
+                        </div>
+                        <div />
+                        <div className="text-right text-[12px] text-base-content/60">
+                          {formatTokensFull(model.tokens)}
+                        </div>
+                        <div />
+                        <div className="text-right text-[12px] text-base-content/60">{formatCost(model.cost)}</div>
+                        <div />
+                        <div />
+                      </div>
+                    ))}
+                  </div>
+                )}
               </div>
-            </div>
-          );
-        })}
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/components/metrics/metricsUtils.js
+++ b/components/metrics/metricsUtils.js
@@ -1,0 +1,51 @@
+// Shared color palette and formatting helpers for the Metrics Dashboard.
+// Data-viz accents have no theme equivalent, so a fixed palette is used;
+// everything else in the dashboard relies on DaisyUI design tokens.
+
+export const METRICS_COLORS = [
+  "#10b981",
+  "#8b5cf6",
+  "#f59e0b",
+  "#3b82f6",
+  "#ef4444",
+  "#06b6d4",
+  "#ec4899",
+  "#84cc16",
+  "#f97316",
+  "#6366f1",
+];
+
+export const getMetricsColor = (index) => METRICS_COLORS[index % METRICS_COLORS.length];
+
+// Stable string -> palette-index hash, so the same entity (agent/model/service/
+// api key id) always gets the same color everywhere it's rendered (chart,
+// legend, Models table row dot) without having to thread a shared color map
+// through every component.
+export const hashString = (value) => {
+  let hash = 0;
+  const str = String(value || "");
+  for (let i = 0; i < str.length; i++) {
+    hash = (hash << 5) - hash + str.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash);
+};
+
+export const colorForId = (id) => getMetricsColor(hashString(id));
+
+export const formatTokens = (tokens) => {
+  const n = Number(tokens) || 0;
+  if (n >= 1000000) return `${(n / 1000000).toFixed(1)}M`;
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+  return String(n);
+};
+
+export const formatTokensFull = (tokens) => (Number(tokens) || 0).toLocaleString();
+
+export const formatCost = (cost) => {
+  const n = Number(cost) || 0;
+  if (n === 0) return "$0";
+  if (n < 0.01) return `$${n.toFixed(4)}`;
+  if (n < 1) return `$${n.toFixed(3)}`;
+  return `$${n.toFixed(2)}`;
+};

--- a/components/sliders/BridgeSlider.js
+++ b/components/sliders/BridgeSlider.js
@@ -7,13 +7,19 @@ import CreateNewBridge from "../CreateNewBridge";
 import { MODAL_TYPE } from "@/utils/enums";
 import SearchItems from "../UI/SearchItems";
 
+// Stable fallback reference: `someSelector() || []` recreates a new array on
+// every render while the selected value is falsy, which defeats downstream
+// useCallback/useEffect memoization (SearchItems' filterData/effect) and can
+// spiral into "Maximum update depth exceeded".
+const EMPTY_BRIDGES_LIST = [];
+
 function BridgeSlider() {
   const router = useRouter();
   const pathName = usePathname();
   const searchParams = useSearchParams();
   const path = pathName.split("?")[0].split("/");
 
-  const bridgesList = useCustomSelector((state) => state.bridgeReducer.org[path[2]]?.orgs) || [];
+  const bridgesList = useCustomSelector((state) => state.bridgeReducer.org[path[2]]?.orgs) || EMPTY_BRIDGES_LIST;
   const defaultBridgeType = searchParams?.get("type")?.toLowerCase() === "chatbot" ? "chatbot" : "api";
 
   const [filteredBridgesList, setFilteredBridgesList] = useState(bridgesList);

--- a/config/metricsApi.js
+++ b/config/metricsApi.js
@@ -35,6 +35,32 @@ export const getMetricsDataApi = async ({
   }
 };
 
+// Real success vs failed request counts per time bucket, sourced from
+// conversation_logs (same table the Agent Analytics page uses) - not the
+// Timescale rollups, which never track failures. bridge_id/model/service are
+// optional multi-select filters (array or single value); there is no
+// apikey_id filter here because conversation_logs has no apikey_id column.
+// Also returns `by_agent`: real per-agent input/output token totals from the
+// same source, for the Models table's token breakdown columns.
+export const getRequestsActivityApi = async ({ bridge_id, model, service, start_date, end_date }) => {
+  try {
+    const response = await axios.post(`${URL}/api/metrics/requests-activity`, {
+      bridge_id,
+      model,
+      service,
+      start_date,
+      end_date,
+    });
+    return {
+      data: response.data?.data || [],
+      byAgent: response.data?.by_agent || [],
+    };
+  } catch (error) {
+    console.error(error);
+    return { data: [], byAgent: [] };
+  }
+};
+
 // User Feedback and Analytics APIs
 export const userFeedbackCount = async ({ bridge_id, user_feedback }) => {
   try {

--- a/customHooks/useMetricsData.js
+++ b/customHooks/useMetricsData.js
@@ -2,6 +2,47 @@ import { useState, useCallback } from "react";
 import { getMetricsDataApi } from "@/config/index";
 import { METRICS_FACTOR_OPTIONS } from "@/utils/enums";
 
+const resolveServiceName = (serviceKey, services = []) =>
+  Array.isArray(services) ? services.find((svc) => svc?.value === serviceKey)?.displayName || serviceKey : serviceKey;
+
+// Duration (in hours) of each preset in the 0-indexed frontend range scheme,
+// mirroring the intervals buildWhereClause applies on the backend
+// (1h,3h,6h,12h,1d,2d,7d,14d,30d). Used to compute an equal-length
+// "previous period" window for the delta-vs-previous-period comparison.
+const RANGE_DURATION_HOURS = [1, 3, 6, 12, 24, 48, 168, 336, 720];
+
+// Resolves the currently selected preset/custom range to an explicit
+// {start, end} window - needed by any endpoint (like Request Activity) that
+// takes explicit dates rather than a backend-side range code.
+export const computeCurrentWindow = (range, customStartDate, customEndDate) => {
+  if (range === 10 && customStartDate && customEndDate) {
+    return { start: new Date(customStartDate), end: new Date(customEndDate) };
+  }
+  const durationMs = (RANGE_DURATION_HOURS[range] ?? 168) * 60 * 60 * 1000;
+  return { start: new Date(Date.now() - durationMs), end: new Date() };
+};
+
+// Returns the immediately-preceding window of equal length to the currently
+// selected range/custom dates, e.g. "Last 7 Days" -> the 7 days before that.
+export const computePreviousWindow = (range, customStartDate, customEndDate) => {
+  let currentStart;
+  let durationMs;
+
+  if (range === 10 && customStartDate && customEndDate) {
+    currentStart = new Date(customStartDate);
+    durationMs = new Date(customEndDate).getTime() - currentStart.getTime();
+  } else {
+    durationMs = (RANGE_DURATION_HOURS[range] ?? 168) * 60 * 60 * 1000;
+    currentStart = new Date(Date.now() - durationMs);
+  }
+
+  if (!Number.isFinite(durationMs) || durationMs <= 0) return null;
+
+  const prevEnd = currentStart;
+  const prevStart = new Date(currentStart.getTime() - durationMs);
+  return { prevStart, prevEnd };
+};
+
 // Data conversion logic extracted from the main component
 export const convertApiData = (
   apiData,
@@ -9,11 +50,11 @@ export const convertApiData = (
   range = 1,
   allBridges = [],
   apiKeys = [],
+  services = [],
   customStartDate = null,
   customEndDate = null
 ) => {
-  const factorOptions = ["bridge_id", "apikey_id", "model"];
-  const currentFactor = factorOptions[factor];
+  const currentFactor = METRICS_FACTOR_OPTIONS[factor] || "bridge_id";
 
   const uniqueEntries = {};
 
@@ -34,15 +75,8 @@ export const convertApiData = (
         : entryDate.toISOString().split("T")[0]; // YYYY-MM-DD
 
     const entryId = entry[currentFactor];
-    const uniqueKey = `${key}+${
-      currentFactor === "bridge_id"
-        ? entry.bridge_id
-        : currentFactor === "apikey_id"
-          ? entry.apikey_id
-          : currentFactor === "model"
-            ? entry.model
-            : ""
-    }`;
+    const uniqueKey = `${key}+${entryId ?? ""}`;
+    const latencyValue = entry.latency_sum != null ? Number(entry.latency_sum) : null;
 
     if (!uniqueEntries[uniqueKey]) {
       uniqueEntries[uniqueKey] = {
@@ -51,11 +85,15 @@ export const convertApiData = (
         cost: entry.cost_sum || 0,
         tokens: entry.total_token_count || 0,
         successCount: entry.success_count || 0,
+        latencyTotal: latencyValue || 0,
+        latencyRows: latencyValue != null ? 1 : 0,
       };
     } else {
       uniqueEntries[uniqueKey].cost += entry.cost_sum || 0;
       uniqueEntries[uniqueKey].tokens += entry.total_token_count || 0;
       uniqueEntries[uniqueKey].successCount += entry.success_count || 0;
+      uniqueEntries[uniqueKey].latencyTotal += latencyValue || 0;
+      uniqueEntries[uniqueKey].latencyRows += latencyValue != null ? 1 : 0;
     }
   });
 
@@ -160,12 +198,21 @@ export const convertApiData = (
 
     if (groupedByDate[dateStr]) {
       let name = "";
+      // Resolved alongside name so the Models table can show the same
+      // provider icon (openai/anthropic/...) the real Agents list shows -
+      // only meaningful for Agent/Service groupings, where "which service"
+      // is unambiguous; left undefined for API Key/Model groupings.
+      let itemService;
       if (currentFactor === "bridge_id") {
         const bridge = allBridges.find((b) => b._id === entry.id);
         name = bridge ? bridge.name : `Bridge ${entry.id?.substring(0, 6)}`;
+        itemService = bridge?.service;
       } else if (currentFactor === "apikey_id") {
         const apiKey = apiKeys.find((k) => k._id === entry.id);
         name = apiKey ? apiKey.name : `API Key ${entry.id?.substring(0, 6)}`;
+      } else if (currentFactor === "service") {
+        name = resolveServiceName(entry.id, services);
+        itemService = entry.id;
       } else {
         name = entry.id || "Unknown Model";
       }
@@ -176,13 +223,18 @@ export const convertApiData = (
         groupedByDate[dateStr].items[existingItemIndex].cost += entry.cost;
         groupedByDate[dateStr].items[existingItemIndex].tokens += entry.tokens;
         groupedByDate[dateStr].items[existingItemIndex].successCount += entry.successCount;
+        groupedByDate[dateStr].items[existingItemIndex].latencyTotal += entry.latencyTotal;
+        groupedByDate[dateStr].items[existingItemIndex].latencyRows += entry.latencyRows;
       } else {
         groupedByDate[dateStr].items.push({
           id: entry.id,
           name: name,
+          service: itemService,
           cost: entry.cost,
           tokens: entry.tokens,
           successCount: entry.successCount,
+          latencyTotal: entry.latencyTotal,
+          latencyRows: entry.latencyRows,
         });
       }
 
@@ -213,49 +265,223 @@ export const aggregateDataByFactor = (rawData) => {
         aggregated[itemId] = {
           id: itemId,
           name: itemName,
+          service: item.service,
           tokens: 0,
           cost: 0,
           successCount: 0,
+          latencyTotal: 0,
+          latencyRows: 0,
         };
       }
 
       aggregated[itemId].tokens += item.tokens;
       aggregated[itemId].cost += item.cost;
       aggregated[itemId].successCount += item.successCount;
+      aggregated[itemId].latencyTotal += item.latencyTotal || 0;
+      aggregated[itemId].latencyRows += item.latencyRows || 0;
     });
+  });
+
+  return Object.values(aggregated)
+    .map((item) => ({
+      ...item,
+      avgLatency: item.latencyRows > 0 ? item.latencyTotal / item.latencyRows : 0,
+    }))
+    .sort((a, b) => b.tokens - a.tokens);
+};
+
+// Aggregate raw API rows (grouped by a dimension on the server) into a summary list.
+export const aggregateMetricsByKey = (apiData, keyField, nameResolver = (id) => id) => {
+  const aggregated = {};
+
+  (Array.isArray(apiData) ? apiData : []).forEach((entry) => {
+    const id = entry[keyField];
+    if (id === null || id === undefined) return;
+
+    if (!aggregated[id]) {
+      aggregated[id] = {
+        id,
+        name: nameResolver(id),
+        tokens: 0,
+        cost: 0,
+        successCount: 0,
+      };
+    }
+
+    aggregated[id].tokens += entry.total_token_count || 0;
+    aggregated[id].cost += entry.cost_sum || 0;
+    aggregated[id].successCount += entry.success_count || 0;
   });
 
   return Object.values(aggregated).sort((a, b) => b.tokens - a.tokens);
 };
 
+// Per-agent breakdown of which models it used (and each model's tokens/cost),
+// built from the SAME raw rows the main chart already fetches when grouped by
+// Agent - the backend now carries a `model` column on every row in that case
+// specifically so this doesn't need its own N-agents extra API calls.
+export const buildAgentModelBreakdown = (apiData) => {
+  const byAgent = {};
+  (Array.isArray(apiData) ? apiData : []).forEach((entry) => {
+    if (!entry.bridge_id || !entry.model) return;
+    if (!byAgent[entry.bridge_id]) byAgent[entry.bridge_id] = {};
+    const models = byAgent[entry.bridge_id];
+    if (!models[entry.model]) models[entry.model] = { id: entry.model, name: entry.model, tokens: 0, cost: 0 };
+    models[entry.model].tokens += entry.total_token_count || 0;
+    models[entry.model].cost += entry.cost_sum || 0;
+  });
+  const result = {};
+  Object.keys(byAgent).forEach((agentId) => {
+    result[agentId] = Object.values(byAgent[agentId]).sort((a, b) => b.tokens - a.tokens);
+  });
+  return result;
+};
+
+// Per-service summary for the dashboard cards
+export const aggregateByService = (apiData, services = []) =>
+  aggregateMetricsByKey(apiData, "service", (id) => resolveServiceName(id, services));
+
+// Unique model options for the model filter
+export const getModelOptions = (apiData) => {
+  const seen = new Set();
+  const options = [];
+  (Array.isArray(apiData) ? apiData : []).forEach((entry) => {
+    if (entry.model && !seen.has(entry.model)) {
+      seen.add(entry.model);
+      options.push({ id: entry.model, name: entry.model });
+    }
+  });
+  return options.sort((a, b) => a.name.localeCompare(b.name));
+};
+
+// Sum cost/tokens/successful-requests across a raw (pre-conversion) API rows
+// array - used for the headline totals, current vs previous period.
+const sumTotals = (apiData) =>
+  (Array.isArray(apiData) ? apiData : []).reduce(
+    (acc, entry) => ({
+      cost: acc.cost + (entry.cost_sum || 0),
+      tokens: acc.tokens + (entry.total_token_count || 0),
+      requests: acc.requests + (entry.success_count || 0),
+    }),
+    { cost: 0, tokens: 0, requests: 0 }
+  );
+
+const EMPTY_HEADLINE_METRIC = { current: 0, previous: null, deltaPct: null };
+
 // Custom hook for metrics data management
-export const useMetricsData = (orgId, allBridges, apikeyData) => {
+export const useMetricsData = (orgId, allBridges, apikeyData, services = []) => {
   const [rawData, setRawData] = useState([]);
+  const [modelOptions, setModelOptions] = useState([]);
+  const [agentModelBreakdown, setAgentModelBreakdown] = useState({});
   const [loading, setLoading] = useState(false);
+  const [headlineStats, setHeadlineStats] = useState({
+    cost: EMPTY_HEADLINE_METRIC,
+    tokens: EMPTY_HEADLINE_METRIC,
+    requests: EMPTY_HEADLINE_METRIC,
+  });
 
   const fetchMetricsData = useCallback(
-    async (factor, range, bridge, customStartDate, customEndDate) => {
+    async ({ factor, range, bridge, apikey, model, service, customStartDate, customEndDate }) => {
       setLoading(true);
 
       try {
+        // Each filter accepts a single id (legacy) or an array (multi-select).
+        // Empty arrays are sent as undefined so the backend applies no filter.
+        const asFilterValue = (value) =>
+          Array.isArray(value) ? (value.length ? value : undefined) : value || undefined;
+
         const requestBody = {
           range: range === 10 ? 10 : range + 1,
-          factor: METRICS_FACTOR_OPTIONS[factor],
+          factor: METRICS_FACTOR_OPTIONS[factor] || "bridge_id",
           org_id: orgId,
+          apikey_id: asFilterValue(apikey),
+          service: asFilterValue(service),
+          model: asFilterValue(model),
+          bridge_id: asFilterValue(bridge),
         };
-
-        if (bridge?.bridge_id) {
-          requestBody.bridge_id = bridge.bridge_id;
-        }
 
         if (range === 10 && customStartDate && customEndDate) {
           requestBody.start_date = customStartDate;
           requestBody.end_date = customEndDate;
         }
 
-        const response = await getMetricsDataApi(requestBody);
-        const data = convertApiData(response, factor, range, allBridges, apikeyData, customStartDate, customEndDate);
-        setRawData(data);
+        const isModelFactor = requestBody.factor === "model";
+
+        // Named calls (instead of a positional array) so a result can never
+        // be mis-assigned depending on which optional calls end up being made.
+        const callMap = {
+          main: getMetricsDataApi(requestBody),
+        };
+
+        // Model options (not needed when already grouping by model). Excludes
+        // the model filter on itself - this call's job is to enumerate every
+        // valid model given the OTHER filters, not to further restrict by
+        // whichever model(s) happen to already be selected (that would make
+        // the dropdown collapse to only ever showing what's already picked).
+        if (!isModelFactor) {
+          callMap.model = getMetricsDataApi({ ...requestBody, factor: "model", model: undefined });
+        }
+
+        // Previous period (delta-vs-previous-period): same filters, the
+        // immediately-preceding window of equal length. Always requested as
+        // an explicit custom range (range=10) so it's independent of whatever
+        // preset/custom range the current period uses.
+        const previousWindow = computePreviousWindow(range, customStartDate, customEndDate);
+        if (previousWindow) {
+          callMap.previous = getMetricsDataApi({
+            ...requestBody,
+            range: 10,
+            start_date: previousWindow.prevStart,
+            end_date: previousWindow.prevEnd,
+          });
+        }
+
+        const callKeys = Object.keys(callMap);
+        const results = await Promise.all(callKeys.map((key) => callMap[key]));
+        const dataByKey = {};
+        callKeys.forEach((key, index) => {
+          dataByKey[key] = results[index];
+        });
+
+        setRawData(
+          convertApiData(
+            dataByKey.main,
+            factor,
+            range,
+            allBridges,
+            apikeyData,
+            services,
+            customStartDate,
+            customEndDate
+          )
+        );
+        if (dataByKey.model) setModelOptions(getModelOptions(dataByKey.model));
+        setAgentModelBreakdown(requestBody.factor === "bridge_id" ? buildAgentModelBreakdown(dataByKey.main) : {});
+
+        const currentTotals = sumTotals(dataByKey.main);
+        const previousTotals = dataByKey.previous ? sumTotals(dataByKey.previous) : null;
+        const deltaPct = (current, previous) => {
+          if (previous === null) return null;
+          if (previous === 0) return current > 0 ? 100 : null;
+          return ((current - previous) / previous) * 100;
+        };
+        setHeadlineStats({
+          cost: {
+            current: currentTotals.cost,
+            previous: previousTotals?.cost ?? null,
+            deltaPct: deltaPct(currentTotals.cost, previousTotals?.cost ?? null),
+          },
+          tokens: {
+            current: currentTotals.tokens,
+            previous: previousTotals?.tokens ?? null,
+            deltaPct: deltaPct(currentTotals.tokens, previousTotals?.tokens ?? null),
+          },
+          requests: {
+            current: currentTotals.requests,
+            previous: previousTotals?.requests ?? null,
+            deltaPct: deltaPct(currentTotals.requests, previousTotals?.requests ?? null),
+          },
+        });
       } catch (error) {
         console.error("Error fetching metrics data:", error);
         setRawData([]);
@@ -263,12 +489,15 @@ export const useMetricsData = (orgId, allBridges, apikeyData) => {
         setLoading(false);
       }
     },
-    [orgId, allBridges, apikeyData]
+    [orgId, allBridges, apikeyData, services]
   );
 
   return {
     rawData,
+    modelOptions,
+    agentModelBreakdown,
     loading,
+    headlineStats,
     fetchMetricsData,
   };
 };

--- a/customHooks/useMetricsURL.js
+++ b/customHooks/useMetricsURL.js
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { useQueryParams } from "./useQueryParams";
+import { METRICS_TIME_RANGE_OPTIONS } from "@/utils/enums";
 
 export const useMetricsURL = () => {
   const { setParams } = useQueryParams();
@@ -11,26 +12,13 @@ export const useMetricsURL = () => {
     [setParams]
   );
 
-  const getDisplayRangeText = useCallback((range, customStartDate, customEndDate, TIME_RANGE_OPTIONS) => {
-    if (range === 10 && customStartDate && customEndDate) {
-      const formatDisplayDate = (dateString) => {
-        const date = new Date(dateString);
-        return date.toLocaleDateString("en-US", {
-          year: "numeric",
-          month: "short",
-          day: "numeric",
-        });
-      };
-
-      const start = formatDisplayDate(customStartDate);
-      const end = formatDisplayDate(customEndDate);
-      return `${start} - ${end}`;
-    }
-    return TIME_RANGE_OPTIONS[range] || "Select Range";
+  // Map an underlying range code (e.g. 2/4/6) to its display label.
+  const getTimeRangeLabel = useCallback((range) => {
+    return METRICS_TIME_RANGE_OPTIONS.find((option) => option.range === range)?.label || "Select Range";
   }, []);
 
   return {
     updateURLParams,
-    getDisplayRangeText,
+    getTimeRangeLabel,
   };
 };

--- a/customHooks/useRequestActivity.js
+++ b/customHooks/useRequestActivity.js
@@ -1,0 +1,51 @@
+import { useState, useCallback } from "react";
+import { getRequestsActivityApi } from "@/config/index";
+import { computeCurrentWindow } from "./useMetricsData";
+
+// Real success/failed request counts over time (POST /api/metrics/requests-activity),
+// sourced from conversation_logs - independent of the Timescale-backed useMetricsData
+// hook above, since failure tracking only exists in the conversation_logs pipeline.
+// Also returns a real per-agent input/output token breakdown from the same source,
+// keyed by bridge_id for the Models table to look up directly.
+export const useRequestActivity = () => {
+  const [data, setData] = useState([]);
+  const [agentTokenBreakdown, setAgentTokenBreakdown] = useState({});
+  const [loading, setLoading] = useState(false);
+
+  const fetchRequestActivity = useCallback(
+    async ({ range, bridge, model, service, customStartDate, customEndDate }) => {
+      setLoading(true);
+      try {
+        const { start, end } = computeCurrentWindow(range, customStartDate, customEndDate);
+        const asFilterValue = (value) =>
+          Array.isArray(value) ? (value.length ? value : undefined) : value || undefined;
+        const { data: rows, byAgent } = await getRequestsActivityApi({
+          bridge_id: asFilterValue(bridge),
+          model: asFilterValue(model),
+          service: asFilterValue(service),
+          start_date: start,
+          end_date: end,
+        });
+        setData(Array.isArray(rows) ? rows : []);
+        const breakdown = {};
+        (Array.isArray(byAgent) ? byAgent : []).forEach((row) => {
+          if (!row.bridge_id) return;
+          breakdown[row.bridge_id] = {
+            inputTokens: Number(row.input_tokens) || 0,
+            outputTokens: Number(row.output_tokens) || 0,
+          };
+        });
+        setAgentTokenBreakdown(breakdown);
+      } catch (error) {
+        console.error("Error fetching request activity:", error);
+        setData([]);
+        setAgentTokenBreakdown({});
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
+
+  return { data, agentTokenBreakdown, loading, fetchRequestActivity };
+};

--- a/icons/minimax.tsx
+++ b/icons/minimax.tsx
@@ -6,18 +6,18 @@ const MinimaxIcon = ({ height, width }) => {
     <svg width={width} height={height} viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg">
       <defs>
         <linearGradient id="wave" x1="0" y1="0" x2="1024" y2="0" gradientUnits="userSpaceOnUse">
-          <stop offset="0" stop-color="#e6197f" />
-          <stop offset="0.5" stop-color="#ee2f6a" />
-          <stop offset="1" stop-color="#f4562f" />
+          <stop offset="0" stopColor="#e6197f" />
+          <stop offset="0.5" stopColor="#ee2f6a" />
+          <stop offset="1" stopColor="#f4562f" />
         </linearGradient>
       </defs>
       <path
         d="M60,490 V610 H175 V360 H290 V800 H405 V130 H520 V870 H635 V130 H750 V760 H865 V330 H955 V600"
         fill="none"
         stroke="url(#wave)"
-        stroke-width="84"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeWidth="84"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
     </svg>
   );

--- a/utils/enums.js
+++ b/utils/enums.js
@@ -167,7 +167,27 @@ export const TIME_RANGE_OPTIONS = [
   "30 days",
 ];
 
-export const METRICS_FACTOR_OPTIONS = ["bridge_id", "apikey_id", "model"];
+export const METRICS_FACTOR_OPTIONS = ["bridge_id", "apikey_id", "model", "service"];
+export const METRICS_FACTOR_LABELS = ["Agents", "API Keys", "Models", "Services"];
+
+// Metrics dashboard time range presets. The range value here is the same
+// 0-indexed value convertApiData's bucketing switch already expects (it
+// mirrors TIME_RANGE_OPTIONS' index order: 0 is 1 hour, 1 is 3 hours, 2 is 6
+// hours, 3 is 12 hours, 4 is 1 day, 5 is 2 days, 6 is 7 days, 7 is 14 days, 8
+// is 30 days) - useMetricsData translates it to the real /api/metrics backend
+// code by adding one before sending the request, so adding presets here only
+// means picking the right existing index, not inventing a new mapping. The
+// value 10 is a separate, pre-existing special case for a custom start/end
+// date range (see convertApiData's handling of that same value).
+export const METRICS_TIME_RANGE_OPTIONS = [
+  { label: "Last 1 Hour", range: 0 },
+  { label: "Last 6 Hours", range: 2 },
+  { label: "Last 24 Hours", range: 4 },
+  { label: "Last 7 Days", range: 6 },
+  { label: "Last 30 Days", range: 8 },
+  { label: "Custom Range", range: 10 },
+];
+
 export const KNOWLEDGE_BASE_COLUMNS = ["name", "description", "created", "strategy", "chunk"];
 export const KNOWLEDGE_BASE_SECTION_TYPES = [
   { value: "default", label: "Default" },


### PR DESCRIPTION
Rebuilds the Metrics dashboard, adds multi-select filters (Agent/Service/Model/API Key), a stacked cost/usage chart with delta-vs-previous-period, a real Request Activity card (success/fail/latency), per-agent token breakdown, and CSV/JSON export. Pairs with the gtwy-node PR.
