### PR TITLE
feat: enhance EmbedAnalyticsTab layout with bridge ID display

### DIFF
--- a/components/integration/EmbedAnalyticsTab.js
+++ b/components/integration/EmbedAnalyticsTab.js
@@ -430,7 +430,12 @@ const EmbedAnalyticsTab = ({ data }) => {
                                       key={a.bridge_id}
                                       className="flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2 text-sm"
                                     >
-                                      <span className="font-medium truncate">{a.name}</span>
+                                      <div className="flex flex-col truncate">
+                                        <span className="font-medium truncate">{a.name}</span>
+                                        <span className="text-[11px] text-base-content/50 truncate">
+                                          {a.bridge_id}
+                                        </span>
+                                      </div>
                                       <span className="text-xs text-base-content/70 shrink-0">
                                         {a.total_requests} req · {formatCost(a.est_cost)}
                                       </span>


### PR DESCRIPTION
Updated the EmbedAnalyticsTab component to include the bridge ID below the name in a new flex column layout for improved readability.